### PR TITLE
Assets preview

### DIFF
--- a/server/lib/coflux/orchestration/results.ex
+++ b/server/lib/coflux/orchestration/results.ex
@@ -366,26 +366,28 @@ defmodule Coflux.Orchestration.Results do
   end
 
   def create_asset(db, execution_id, type, path, blob_key, metadata) do
+    now = current_timestamp()
     {:ok, blob_id} = get_or_create_blob(db, blob_key, metadata)
 
     insert_one(db, :assets, %{
       execution_id: execution_id,
       type: type,
       path: path,
-      blob_id: blob_id
+      blob_id: blob_id,
+      created_at: now
     })
   end
 
   def get_asset_by_id(db, asset_id, load_metadata) do
     case query_one!(
            db,
-           "SELECT execution_id, type, path, blob_id FROM assets WHERE id = ?1",
+           "SELECT execution_id, type, path, blob_id, created_at FROM assets WHERE id = ?1",
            {asset_id}
          ) do
-      {:ok, {execution_id, type, path, blob_id}} ->
+      {:ok, {execution_id, type, path, blob_id, created_at}} ->
         {:ok, {blob_key, metadata}} = get_blob_by_id(db, blob_id, load_metadata)
 
-        {:ok, {execution_id, type, path, blob_key, metadata}}
+        {:ok, {execution_id, type, path, blob_key, created_at, metadata}}
     end
   end
 

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -443,7 +443,7 @@ defmodule Coflux.Orchestration.Server do
   end
 
   def handle_call({:get_asset, asset_id, from_execution_id}, _from, state) do
-    {:ok, {asset_execution_id, type, path, blob_key, _}} =
+    {:ok, {asset_execution_id, type, path, blob_key, _, _}} =
       Results.get_asset_by_id(state.db, asset_id, false)
 
     state =
@@ -940,7 +940,7 @@ defmodule Coflux.Orchestration.Server do
   end
 
   defp resolve_asset(db, asset_id, include_execution) do
-    {:ok, {execution_id, type, path, blob_key, metadata}} =
+    {:ok, {execution_id, type, path, blob_key, created_at, metadata}} =
       Results.get_asset_by_id(db, asset_id, true)
 
     result = %{
@@ -948,7 +948,8 @@ defmodule Coflux.Orchestration.Server do
       path: path,
       metadata: metadata,
       blob_key: blob_key,
-      execution_id: execution_id
+      execution_id: execution_id,
+      created_at: created_at
     }
 
     if include_execution do

--- a/server/lib/coflux/store.ex
+++ b/server/lib/coflux/store.ex
@@ -120,6 +120,8 @@ defmodule Coflux.Store do
 
   defp build(row, model, columns) do
     if model do
+      Code.ensure_loaded!(model)
+
       prepare =
         if function_exported?(model, :prepare, 1),
           do: &model.prepare/1,

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -232,7 +232,8 @@ defmodule Coflux.Topics.Run do
       type: asset.type,
       path: asset.path,
       metadata: asset.metadata,
-      blobKey: asset.blob_key
+      blobKey: asset.blob_key,
+      createdAt: asset.created_at
     }
   end
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
         "@headlessui/react": "^1.7.18",
         "@tabler/icons-react": "^2.45.0",
         "@topical/react": "^0.2.0",
+        "@zip.js/zip.js": "^2.7.34",
         "classnames": "^2.5.1",
         "lodash": "^4.17.21",
         "luxon": "^3.4.4",
@@ -1117,6 +1118,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.34",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.34.tgz",
+      "integrity": "sha512-SWAK+hLYKRHswhakNUirPYrdsflSFOxykUckfbWDcPvP8tjLuV5EWyd3GHV0hVaJLDps40jJnv8yQVDbWnQDfg==",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -5948,6 +5959,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@zip.js/zip.js": {
+      "version": "2.7.34",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.34.tgz",
+      "integrity": "sha512-SWAK+hLYKRHswhakNUirPYrdsflSFOxykUckfbWDcPvP8tjLuV5EWyd3GHV0hVaJLDps40jJnv8yQVDbWnQDfg=="
     },
     "acorn": {
       "version": "8.11.3",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "@headlessui/react": "^1.7.18",
     "@tabler/icons-react": "^2.45.0",
     "@topical/react": "^0.2.0",
+    "@zip.js/zip.js": "^2.7.34",
     "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -96,6 +96,7 @@ CREATE TABLE assets (
   type INTEGER NOT NULL,
   path TEXT NOT NULL,
   blob_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
   FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE,
   FOREIGN KEY (blob_id) REFERENCES blobs ON DELETE RESTRICT
 );

--- a/server/src/App.tsx
+++ b/server/src/App.tsx
@@ -13,6 +13,7 @@ import {
   RunPage,
   GraphPage,
   TimelinePage,
+  AssetsPage,
   RunsPage,
   LogsPage,
   TargetPage,
@@ -53,6 +54,7 @@ export default function App() {
                   <Route index={true} element={<RunPage />} />
                   <Route path="graph" element={<GraphPage />} />
                   <Route path="timeline" element={<TimelinePage />} />
+                  <Route path="assets" element={<AssetsPage />} />
                   <Route path="runs" element={<RunsPage />} />
                   <Route path="logs" element={<LogsPage />} />
                 </Route>

--- a/server/src/assets.ts
+++ b/server/src/assets.ts
@@ -1,0 +1,25 @@
+import * as models from "./models";
+import { humanSize, pluralise } from "./utils";
+
+export function getAssetMetadata(asset: models.Asset) {
+  const parts = [];
+  switch (asset.type) {
+    case 0:
+      if ("size" in asset.metadata) {
+        parts.push(humanSize(asset.metadata.size));
+      }
+      if ("type" in asset.metadata && asset.metadata.type) {
+        parts.push(asset.metadata.type);
+      }
+      break;
+    case 1:
+      if ("count" in asset.metadata) {
+        parts.push(pluralise(asset.metadata.count, "file"));
+      }
+      if ("totalSize" in asset.metadata) {
+        parts.push(humanSize(asset.metadata.totalSize));
+      }
+      break;
+  }
+  return parts;
+}

--- a/server/src/components/AssetIcon.tsx
+++ b/server/src/components/AssetIcon.tsx
@@ -1,0 +1,35 @@
+import { IconFile, IconFileText, IconFolder } from "@tabler/icons-react";
+
+import * as models from "../models";
+
+function iconForAsset(asset: models.Asset) {
+  switch (asset.type) {
+    case 0:
+      const type = asset.metadata["type"];
+      switch (type?.split("/")[0]) {
+        case "text":
+          return IconFileText;
+        default:
+          return IconFile;
+      }
+    case 1:
+      return IconFolder;
+    default:
+      throw new Error(`unrecognised asset type (${asset.type})`);
+  }
+}
+
+type AssetIconProps = {
+  asset: models.Asset;
+  size?: number;
+  className?: string;
+};
+
+export default function AssetIcon({
+  asset,
+  size = 16,
+  className,
+}: AssetIconProps) {
+  const Icon = iconForAsset(asset);
+  return <Icon size={size} className={className} />;
+}

--- a/server/src/components/AssetLink.tsx
+++ b/server/src/components/AssetLink.tsx
@@ -1,0 +1,115 @@
+import { Fragment, ReactNode, MouseEvent, useCallback, useState } from "react";
+import { IconX } from "@tabler/icons-react";
+
+import * as models from "../models";
+import { humanSize, pluralise } from "../utils";
+
+function formatMetadata(asset: models.Asset) {
+  const parts = [];
+  switch (asset.type) {
+    case 0:
+      if ("size" in asset.metadata) {
+        parts.push(humanSize(asset.metadata.size));
+      }
+      if ("type" in asset.metadata && asset.metadata.type) {
+        parts.push(asset.metadata.type);
+      }
+      break;
+    case 1:
+      if ("count" in asset.metadata) {
+        parts.push(pluralise(asset.metadata.count, "file"));
+      }
+      if ("totalSize" in asset.metadata) {
+        parts.push(humanSize(asset.metadata.totalSize));
+      }
+      break;
+  }
+  return parts.join("; ");
+}
+
+type Props = {
+  asset: models.Asset;
+  className?: string;
+  children: ReactNode;
+};
+
+export default function AssetLink({ asset, className, children }: Props) {
+  const mimeType = asset.type == 0 ? asset.metadata["type"] : undefined;
+  const [open, setOpen] = useState<boolean>(false);
+  const [content, setContent] = useState<
+    ["image", string] | ["text", string]
+  >();
+  const handleClick = useCallback(
+    (ev: MouseEvent) => {
+      if (!ev.ctrlKey) {
+        ev.preventDefault();
+        // TODO: confirm for large file?
+        setOpen(true);
+        if (!content) {
+          fetch(`/blobs/${asset.blobKey}`)
+            .then((resp) => {
+              if (resp.ok) {
+                if (mimeType?.startsWith("image/")) {
+                  return resp.blob().then((blob) => {
+                    const url = URL.createObjectURL(blob);
+                    setContent(["image", url]);
+                  });
+                } else {
+                  return resp.text().then((text) => {
+                    setContent(["text", text]);
+                  });
+                }
+              } else {
+                return Promise.reject();
+              }
+            })
+            .catch(() => {
+              alert("Failed to load blob.");
+            });
+        }
+      }
+    },
+    [content, mimeType],
+  );
+  const handleCloseClick = useCallback(() => {
+    setOpen(false);
+  }, []);
+  return (
+    <Fragment>
+      {open && (
+        <div className="z-30 fixed inset-0 flex">
+          <div
+            className="absolute bg-black/60 inset-0"
+            onClick={handleCloseClick}
+          />
+          <div className="relative bg-white rounded-lg shadow-xl overflow-hidden m-auto min-w-[40vw] min-h-[30vh] max-w-[85vw] max-h-[85vh] flex">
+            <button
+              onClick={handleCloseClick}
+              className="absolute top-2 right-2 bg-slate-100/50 hover:bg-slate-300/50 p-1 rounded-md"
+            >
+              <IconX size={28} />
+            </button>
+            <div className="overflow-auto">
+              {content?.[0] == "image" ? (
+                <img src={content[1]} className="m-auto" />
+              ) : content?.[0] == "text" ? (
+                <pre className="p-3">{content[1]}</pre>
+              ) : (
+                <p>Loading...</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+      <a
+        href={`/blobs/${asset.blobKey}`}
+        title={`${asset.path}\n${formatMetadata(asset)}`}
+        className={className}
+        target={"_blank"}
+        onClick={handleClick}
+      >
+        {children}
+      </a>
+    </Fragment>
+  );
+}

--- a/server/src/components/AssetLink.tsx
+++ b/server/src/components/AssetLink.tsx
@@ -2,30 +2,7 @@ import { Fragment, ReactNode, MouseEvent, useCallback, useState } from "react";
 import { IconX } from "@tabler/icons-react";
 
 import * as models from "../models";
-import { humanSize, pluralise } from "../utils";
-
-function formatMetadata(asset: models.Asset) {
-  const parts = [];
-  switch (asset.type) {
-    case 0:
-      if ("size" in asset.metadata) {
-        parts.push(humanSize(asset.metadata.size));
-      }
-      if ("type" in asset.metadata && asset.metadata.type) {
-        parts.push(asset.metadata.type);
-      }
-      break;
-    case 1:
-      if ("count" in asset.metadata) {
-        parts.push(pluralise(asset.metadata.count, "file"));
-      }
-      if ("totalSize" in asset.metadata) {
-        parts.push(humanSize(asset.metadata.totalSize));
-      }
-      break;
-  }
-  return parts.join("; ");
-}
+import { getAssetMetadata } from "../assets";
 
 type Props = {
   asset: models.Asset;
@@ -105,7 +82,7 @@ export default function AssetLink({ asset, className, children }: Props) {
       )}
       <a
         href={`/blobs/${asset.blobKey}`}
-        title={`${asset.path}\n${formatMetadata(asset)}`}
+        title={`${asset.path}\n${getAssetMetadata(asset).join("; ")}`}
         className={className}
         target={"_blank"}
         onClick={handleClick}

--- a/server/src/components/AssetLink.tsx
+++ b/server/src/components/AssetLink.tsx
@@ -1,8 +1,10 @@
 import { Fragment, ReactNode, MouseEvent, useCallback, useState } from "react";
-import { IconX } from "@tabler/icons-react";
+import { IconDownload, IconX } from "@tabler/icons-react";
+import * as zip from "@zip.js/zip.js";
 
 import * as models from "../models";
-import { getAssetMetadata } from "../assets";
+import { getAssetMetadata, readZipContents } from "../assets";
+import { humanSize } from "../utils";
 
 type Props = {
   asset: models.Asset;
@@ -13,10 +15,12 @@ type Props = {
 export default function AssetLink({ asset, className, children }: Props) {
   const mimeType = asset.type == 0 ? asset.metadata["type"] : undefined;
   const preview =
-    mimeType?.startsWith("image/") || mimeType?.startsWith("text/");
+    asset.type == 1 ||
+    mimeType?.startsWith("image/") ||
+    mimeType?.startsWith("text/");
   const [open, setOpen] = useState<boolean>(false);
   const [content, setContent] = useState<
-    ["image", string] | ["text", string]
+    ["image", string] | ["text", string] | ["zip", zip.Entry[]]
   >();
   const handleClick = useCallback(
     (ev: MouseEvent) => {
@@ -28,7 +32,15 @@ export default function AssetLink({ asset, className, children }: Props) {
           fetch(`/blobs/${asset.blobKey}`)
             .then((resp) => {
               if (resp.ok) {
-                if (mimeType?.startsWith("image/")) {
+                if (asset.type == 1) {
+                  return resp.blob().then((blob) => {
+                    const blobReader = new zip.BlobReader(blob);
+                    const zipReader = new zip.ZipReader(blobReader);
+                    return zipReader.getEntries().then((entries) => {
+                      setContent(["zip", entries]);
+                    });
+                  });
+                } else if (mimeType?.startsWith("image/")) {
                   return resp.blob().then((blob) => {
                     const url = URL.createObjectURL(blob);
                     setContent(["image", url]);
@@ -62,17 +74,46 @@ export default function AssetLink({ asset, className, children }: Props) {
             onClick={handleCloseClick}
           />
           <div className="relative bg-white rounded-lg shadow-xl overflow-hidden m-auto min-w-[40vw] min-h-[30vh] max-w-[85vw] max-h-[85vh] flex">
-            <button
-              onClick={handleCloseClick}
-              className="absolute top-2 right-2 bg-slate-100/50 hover:bg-slate-300/50 p-1 rounded-md"
-            >
-              <IconX size={28} />
-            </button>
-            <div className="overflow-auto">
+            <div className="absolute top-2 right-2 flex gap-2">
+              <a
+                href={`/blobs/${asset.blobKey}`}
+                target="_blank"
+                className="bg-slate-100/50 hover:bg-slate-300/50 p-1 rounded-md"
+                title="Download"
+              >
+                <IconDownload size={20} />
+              </a>
+              <button
+                onClick={handleCloseClick}
+                className="bg-slate-100/50 hover:bg-slate-300/50 p-1 rounded-md"
+                title="Close preview"
+              >
+                <IconX size={20} />
+              </button>
+            </div>
+            <div className="overflow-auto flex-1">
               {content?.[0] == "image" ? (
-                <img src={content[1]} className="m-auto" />
+                <img
+                  src={content[1]}
+                  className="max-w-auto max-h-full m-auto"
+                />
               ) : content?.[0] == "text" ? (
                 <pre className="p-3">{content[1]}</pre>
+              ) : content?.[0] == "zip" ? (
+                <div className="p-3">
+                  <table className="w-full">
+                    <tbody>
+                      {content[1].map((entry) => (
+                        <tr key={entry.filename}>
+                          <td>{entry.filename}</td>
+                          <td className="text-slate-500">
+                            {humanSize(entry.uncompressedSize)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               ) : (
                 <p>Loading...</p>
               )}

--- a/server/src/components/AssetLink.tsx
+++ b/server/src/components/AssetLink.tsx
@@ -35,13 +35,15 @@ type Props = {
 
 export default function AssetLink({ asset, className, children }: Props) {
   const mimeType = asset.type == 0 ? asset.metadata["type"] : undefined;
+  const preview =
+    mimeType?.startsWith("image/") || mimeType?.startsWith("text/");
   const [open, setOpen] = useState<boolean>(false);
   const [content, setContent] = useState<
     ["image", string] | ["text", string]
   >();
   const handleClick = useCallback(
     (ev: MouseEvent) => {
-      if (!ev.ctrlKey) {
+      if (!ev.ctrlKey && preview) {
         ev.preventDefault();
         // TODO: confirm for large file?
         setOpen(true);

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -1,10 +1,4 @@
-import {
-  CSSProperties,
-  Fragment,
-  ReactNode,
-  useCallback,
-  useState,
-} from "react";
+import { CSSProperties, Fragment, useCallback, useState } from "react";
 import classNames from "classnames";
 import { sortBy } from "lodash";
 import { DateTime } from "luxon";
@@ -34,6 +28,7 @@ import Loading from "./Loading";
 import Button from "./common/Button";
 import RunLogs from "./RunLogs";
 import StepLink from "./StepLink";
+import AssetLink from "./AssetLink";
 
 type AttemptSelectorOptionProps = {
   attempt: number;
@@ -229,47 +224,6 @@ function BlobLink({ value }: BlobLinkProps) {
       </a>
       <span className="text-slate-500 text-xs ml-1">({hints.join("; ")})</span>
     </span>
-  );
-}
-
-function formatMetadata(asset: models.Asset) {
-  const parts = [];
-  switch (asset.type) {
-    case 0:
-      if ("size" in asset.metadata) {
-        parts.push(humanSize(asset.metadata.size));
-      }
-      if ("type" in asset.metadata && asset.metadata.type) {
-        parts.push(asset.metadata.type);
-      }
-      break;
-    case 1:
-      if ("count" in asset.metadata) {
-        parts.push(pluralise(asset.metadata.count, "file"));
-      }
-      if ("totalSize" in asset.metadata) {
-        parts.push(humanSize(asset.metadata.totalSize));
-      }
-      break;
-  }
-  return parts.join("; ");
-}
-
-type AssetLinkProps = {
-  asset: models.Asset;
-  className?: string;
-  children: ReactNode;
-};
-
-function AssetLink({ asset, className, children }: AssetLinkProps) {
-  return (
-    <a
-      href={`/blobs/${asset.blobKey}`}
-      title={`${asset.path}\n${formatMetadata(asset)}`}
-      className={className}
-    >
-      {children}
-    </a>
   );
 }
 
@@ -683,9 +637,8 @@ function AssetItem({ asset }: AssetItemProps) {
         className="flex items-center gap-1 bg-white rounded px-1"
       >
         <AssetIcon asset={asset} />
-        <span title={asset.path}>{truncatePath(asset.path)}</span>
+        {truncatePath(asset.path)}
       </AssetLink>
-      <span className="text-slate-500 text-xs">({formatMetadata(asset)})</span>
     </li>
   );
 }
@@ -799,7 +752,7 @@ export default function StepDetail({
         {step.arguments?.length > 0 && (
           <ArgumentsSection arguments_={step.arguments} />
         )}
-        <ExecutionSection execution={execution} />
+        {execution && <ExecutionSection execution={execution} />}
         {execution?.assignedAt && (
           <Fragment>
             <DependenciesSection execution={execution} />

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -17,13 +17,7 @@ import reactStringReplace from "react-string-replace";
 
 import * as models from "../models";
 import Badge from "./Badge";
-import {
-  buildUrl,
-  formatDiff,
-  humanSize,
-  pluralise,
-  truncatePath,
-} from "../utils";
+import { buildUrl, formatDiff, humanSize, truncatePath } from "../utils";
 import Loading from "./Loading";
 import Button from "./common/Button";
 import RunLogs from "./RunLogs";

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -5,14 +5,7 @@ import { DateTime } from "luxon";
 import { Listbox, Transition } from "@headlessui/react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useTopic } from "@topical/react";
-import {
-  IconChevronDown,
-  IconFile,
-  IconFileText,
-  IconFolder,
-  IconFunction,
-  IconPinned,
-} from "@tabler/icons-react";
+import { IconChevronDown, IconFunction, IconPinned } from "@tabler/icons-react";
 import reactStringReplace from "react-string-replace";
 
 import * as models from "../models";
@@ -24,6 +17,7 @@ import RunLogs from "./RunLogs";
 import StepLink from "./StepLink";
 import AssetLink from "./AssetLink";
 import { getAssetMetadata } from "../assets";
+import AssetIcon from "./AssetIcon";
 
 type AttemptSelectorOptionProps = {
   attempt: number;
@@ -220,34 +214,6 @@ function BlobLink({ value }: BlobLinkProps) {
       <span className="text-slate-500 text-xs ml-1">({hints.join("; ")})</span>
     </span>
   );
-}
-
-function iconForAsset(asset: models.Asset) {
-  switch (asset.type) {
-    case 0:
-      const type = asset.metadata["type"];
-      switch (type?.split("/")[0]) {
-        case "text":
-          return IconFileText;
-        default:
-          return IconFile;
-      }
-    case 1:
-      return IconFolder;
-    default:
-      throw new Error(`unrecognised asset type (${asset.type})`);
-  }
-}
-
-type AssetIconProps = {
-  asset: models.Asset;
-  size?: number;
-  className?: string;
-};
-
-function AssetIcon({ asset, size = 16, className }: AssetIconProps) {
-  const Icon = iconForAsset(asset);
-  return <Icon size={size} className={className} />;
 }
 
 type ValueProps = {

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -29,6 +29,7 @@ import Button from "./common/Button";
 import RunLogs from "./RunLogs";
 import StepLink from "./StepLink";
 import AssetLink from "./AssetLink";
+import { getAssetMetadata } from "../assets";
 
 type AttemptSelectorOptionProps = {
   attempt: number;
@@ -631,13 +632,20 @@ type AssetItemProps = {
 
 function AssetItem({ asset }: AssetItemProps) {
   return (
-    <li className="flex items-center gap-1 my-1">
+    <li className="block my-1">
       <AssetLink
         asset={asset}
-        className="flex items-center gap-1 bg-white rounded px-1"
+        className="flex items-start gap-1 rounded hover:bg-white/50 p-1"
       >
-        <AssetIcon asset={asset} />
-        {truncatePath(asset.path)}
+        <AssetIcon asset={asset} size={18} className="mt-1" />
+        <span className="flex flex-col">
+          <span className="">
+            {truncatePath(asset.path) + (asset.type == 1 ? "/" : "")}
+          </span>
+          <span className="text-slate-500 text-xs">
+            {getAssetMetadata(asset).join(", ")}
+          </span>
+        </span>
       </AssetLink>
     </li>
   );

--- a/server/src/layouts/RunLayout.tsx
+++ b/server/src/layouts/RunLayout.tsx
@@ -172,6 +172,7 @@ export default function RunLayout() {
                 </Fragment>
               )}
               <Tab page="logs">Logs</Tab>
+              {!run.recurrent && <Tab page="assets">Assets</Tab>}
             </div>
             <div className="flex-1 basis-0 overflow-auto" ref={ref}>
               <Outlet

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -38,6 +38,7 @@ export type Asset = {
   blobKey: string;
   metadata: Record<string, any>;
   execution?: Reference;
+  createdAt: number;
 };
 
 export type Placeholder =

--- a/server/src/pages/AssetsPage.tsx
+++ b/server/src/pages/AssetsPage.tsx
@@ -1,0 +1,85 @@
+import { useParams } from "react-router-dom";
+import { sortBy } from "lodash";
+
+import * as models from "../models";
+import { useContext } from "../layouts/RunLayout";
+import AssetLink from "../components/AssetLink";
+import AssetIcon from "../components/AssetIcon";
+import StepLink from "../components/StepLink";
+import { getAssetMetadata } from "../assets";
+
+type Item = [
+  string,
+  models.Step,
+  number,
+  models.Execution,
+  string,
+  models.Asset,
+];
+
+export default function AssetsPage() {
+  const { run } = useContext();
+  const { run: runId } = useParams();
+  const assets: Item[] = sortBy(
+    Object.entries(run.steps).flatMap(([stepId, step]) =>
+      Object.entries(step.executions).flatMap(([attempt, execution]) =>
+        Object.entries(execution.assets).map(
+          ([assetId, asset]) =>
+            [
+              stepId,
+              step,
+              parseInt(attempt, 10),
+              execution,
+              assetId,
+              asset,
+            ] as Item,
+        ),
+      ),
+    ),
+    (item) => item[5].createdAt,
+  );
+  return (
+    <div className="p-4">
+      {assets.length ? (
+        <table className="w-full">
+          <tbody className="divide-y divide-slate-100">
+            {assets.map(
+              ([stepId, step, attempt, execution, assetId, asset]) => (
+                <tr key={assetId}>
+                  <td className="py-1">
+                    <StepLink
+                      runId={runId!}
+                      stepId={stepId}
+                      attempt={attempt}
+                      className="block max-w-full rounded truncate leading-none text-sm ring-offset-1 w-40"
+                      activeClassName="ring-2 ring-cyan-400"
+                      hoveredClassName="ring-2 ring-slate-300"
+                    >
+                      <span className="font-mono">{step.target}</span>{" "}
+                      <span className="text-slate-500 text-sm">
+                        ({step.repository})
+                      </span>
+                    </StepLink>
+                  </td>
+                  <td className="py-1">
+                    <AssetLink asset={asset} className="flex items-start gap-1">
+                      <AssetIcon asset={asset} size={18} className="mt-1" />
+                      {asset.path + (asset.type == 1 ? "/" : "")}
+                    </AssetLink>
+                  </td>
+                  <td className="py-1">
+                    <span className="text-slate-500 text-sm">
+                      {getAssetMetadata(asset).join(", ")}
+                    </span>
+                  </td>
+                </tr>
+              ),
+            )}
+          </tbody>
+        </table>
+      ) : (
+        <p>None</p>
+      )}
+    </div>
+  );
+}

--- a/server/src/pages/index.ts
+++ b/server/src/pages/index.ts
@@ -3,6 +3,7 @@ export { default as ProjectPage } from "./ProjectPage";
 export { default as ProjectsPage } from "./ProjectsPage";
 export { default as RunPage } from "./RunPage";
 export { default as GraphPage } from "./GraphPage";
+export { default as AssetsPage } from "./AssetsPage";
 export { default as TimelinePage } from "./TimelinePage";
 export { default as TargetPage } from "./TargetPage";
 export { default as LogsPage } from "./LogsPage";


### PR DESCRIPTION
This adds initial support into the frontend for previewing assets within the web app. This currently works for image and text assets, and also for displaying the contents of directory assets.

Also adds a per-run 'assets' tab, collecting the assets across different steps:

![image](https://github.com/CofluxLabs/coflux/assets/535128/c0305369-e91d-43f7-9c42-6c6823af018a)
