### PR TITLE
Fix file-based repository loading

### DIFF
--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.6
+
+Fixes:
+
+- Loading of file-based (as opposed to module-based) repositories with the agent (i.e., `coflux agent.run path/to/repo.py`).
+
 ## 0.2.5
 
 Enhancements:

--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -1,7 +1,5 @@
 import asyncio
 import click
-import importlib
-import importlib.util
 import os
 import types
 import typing as t
@@ -9,7 +7,7 @@ import watchfiles
 import httpx
 from pathlib import Path
 
-from . import Agent, config
+from . import Agent, config, loader
 
 T = t.TypeVar("T")
 
@@ -80,14 +78,7 @@ def _get_host(argument: str | None) -> str:
 async def _run(agent: Agent, modules: list[types.ModuleType | str]) -> None:
     for module in modules:
         if isinstance(module, str):
-            path = Path(module)
-            if path.is_file():
-                spec = importlib.util.spec_from_file_location(module, path)
-                assert spec
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-            else:
-                module = importlib.import_module(module)
+            module = loader.load_module(module)
         await agent.register_module(module)
     await agent.run()
 

--- a/clients/python/coflux/execution.py
+++ b/clients/python/coflux/execution.py
@@ -16,10 +16,9 @@ import mimetypes
 import zipfile
 import itertools
 import signal
-import importlib
 from pathlib import Path
 
-from . import server, blobs, models, serialisation, annotations
+from . import server, blobs, models, serialisation, annotations, loader
 
 
 _EXECUTION_THRESHOLD_S = 1.0
@@ -643,13 +642,13 @@ def _execute(
     conn,
 ):
     global _channel_context
+    module = loader.load_module(module_name)
     with Channel(execution_id, blob_url_format, conn) as channel:
         threading.Thread(target=channel.run).start()
         _channel_context = channel
         try:
             resolved_arguments = _resolve_arguments(arguments, channel)
             channel.notify_executing()
-            module = importlib.import_module(module_name)
             target = getattr(module, target_name)
             fn = getattr(target, annotations.TARGET_KEY)[1][1]
             value = fn(*resolved_arguments)

--- a/clients/python/coflux/loader.py
+++ b/clients/python/coflux/loader.py
@@ -1,0 +1,16 @@
+import importlib
+import importlib.util
+import types
+from pathlib import Path
+
+
+def load_module(module_name: str) -> types.ModuleType:
+    path = Path(module_name)
+    if path.is_file():
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    else:
+        module = importlib.import_module(module_name)
+    return module

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coflux"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["Joe Freeman <joe@joef.uk>"]
 readme = "README.md"

--- a/server/src/components/TargetsList.tsx
+++ b/server/src/components/TargetsList.tsx
@@ -90,7 +90,9 @@ export default function TargetsList({
             <div key={repository} className="py-2">
               <Link
                 to={buildUrl(
-                  `/projects/${projectId}/repositories/${repository}`,
+                  `/projects/${projectId}/repositories/${encodeURIComponent(
+                    repository,
+                  )}`,
                   { environment: environmentName },
                 )}
                 className={classNames(
@@ -153,7 +155,9 @@ export default function TargetsList({
                         name={name}
                         icon={target.type == "sensor" ? IconCpu : IconSubtask}
                         url={buildUrl(
-                          `/projects/${projectId}/targets/${repository}/${name}`,
+                          `/projects/${projectId}/targets/${encodeURIComponent(
+                            repository,
+                          )}/${name}`,
                           { environment: environmentName },
                         )}
                         isActive={isActive}


### PR DESCRIPTION
Generally repositories are specified as Python modules with the CLI (i.e., `coflux agent.run example.repo`), but the agent is supposed to also support file-based (i.e., `coflux agent.run example/repo.py`). This change fixes specifying file-based repositories. Previously modules were being loaded from path when generating the manifest, but not when executing the task.

This also fixes the UI to handle repository names that contain slashes.