### PR TITLE
Fix error serialisation

### DIFF
--- a/clients/python/coflux/execution.py
+++ b/clients/python/coflux/execution.py
@@ -725,8 +725,7 @@ class Execution:
                 self._process.join()
             case RecordErrorRequest(error):
                 self._status = ExecutionStatus.STOPPING
-                type_, message_, frames = error
-                self._server_notify("put_error", (self._id, type_, message_, frames))
+                self._server_notify("put_error", (self._id, error))
                 self._process.join()
             case RecordCheckpointRequest(arguments):
                 self._server_notify(


### PR DESCRIPTION
#19 partially updated the `put_error` message to take an error tuple, rather than individual properties, but the client wasn't correctly updated, which is fixed here.