### PR TITLE
Initial suspense implementation

### DIFF
--- a/clients/python/coflux/__init__.py
+++ b/clients/python/coflux/__init__.py
@@ -1,6 +1,7 @@
 from .decorators import workflow, task, stub, sensor
 from .context import (
     checkpoint,
+    suspense,
     persist_asset,
     restore_asset,
     log_debug,
@@ -17,6 +18,7 @@ __all__ = [
     "stub",
     "sensor",
     "checkpoint",
+    "suspense",
     "log_debug",
     "log_info",
     "log_warning",

--- a/clients/python/coflux/context.py
+++ b/clients/python/coflux/context.py
@@ -27,7 +27,7 @@ def schedule(
     retries: models.Retries | None = None,
     defer: models.Defer | None = None,
     execute_after: dt.datetime | None = None,
-    delay: int | float | dt.timedelta = 0,
+    delay: float | dt.timedelta = 0,
     memo: list[int] | bool = False,
     requires: models.Requires | None = None,
 ) -> models.Execution[t.Any]:
@@ -45,6 +45,10 @@ def schedule(
         memo=memo,
         requires=requires,
     )
+
+
+def suspense(timeout: float | None):
+    return _get_channel().suspense(timeout)
 
 
 def persist_asset(

--- a/clients/python/coflux/decorators.py
+++ b/clients/python/coflux/decorators.py
@@ -45,7 +45,7 @@ def _parse_wait(
 
 
 def _parse_cache(
-    cache: bool | int | float | dt.timedelta,
+    cache: bool | float | dt.timedelta,
     cache_params: t.Iterable[str] | str | None,
     cache_namespace: str | None,
     cache_version: str | None,
@@ -98,7 +98,7 @@ def _parse_defer(
     )
 
 
-def _parse_delay(delay: int | float | dt.timedelta) -> int | float:
+def _parse_delay(delay: float | dt.timedelta) -> float:
     if isinstance(delay, dt.timedelta):
         return delay.total_seconds()
     return delay
@@ -116,14 +116,14 @@ def _build_definition(
     type: models.TargetType,
     fn: t.Callable,
     wait: bool | t.Iterable[str] | str,
-    cache: bool | int | float | dt.timedelta,
+    cache: bool | float | dt.timedelta,
     cache_params: t.Iterable[str] | str | None,
     cache_namespace: str | None,
     cache_version: str | None,
     retries: int | tuple[int, int] | tuple[int, int, int],
     defer: bool,
     defer_params: t.Iterable[str] | str | None,
-    delay: int | float | dt.timedelta,
+    delay: float | dt.timedelta,
     memo: bool | t.Iterable[str] | str,
     requires: dict[str, str | bool | list[str]] | None,
 ):
@@ -154,14 +154,14 @@ class Target(t.Generic[P, T]):
         repository: str | None = None,
         name: str | None = None,
         wait: bool | t.Iterable[str] | str = False,
-        cache: bool | int | float | dt.timedelta = False,
+        cache: bool | float | dt.timedelta = False,
         cache_params: t.Iterable[str] | str | None = None,
         cache_namespace: str | None = None,
         cache_version: str | None = None,
         retries: int | tuple[int, int] | tuple[int, int, int] = 0,
         defer: bool = False,
         defer_params: t.Iterable[str] | str | None = None,
-        delay: int | float | dt.timedelta = 0,
+        delay: float | dt.timedelta = 0,
         memo: bool | t.Iterable[str] | str = False,
         requires: dict[str, str | bool | list[str]] | None = None,
         is_stub: bool = False,
@@ -265,14 +265,14 @@ def task(
     *,
     name: str | None = None,
     wait: bool | t.Iterable[str] | str = False,
-    cache: bool | int | float | dt.timedelta = False,
+    cache: bool | float | dt.timedelta = False,
     cache_params: t.Iterable[str] | str | None = None,
     cache_namespace: str | None = None,
     cache_version: str | None = None,
     retries: int | tuple[int, int] | tuple[int, int, int] = 0,
     defer: bool = False,
     defer_params: t.Iterable[str] | str | None = None,
-    delay: int | float | dt.timedelta = 0,
+    delay: float | dt.timedelta = 0,
     memo: bool | t.Iterable[str] = False,
     requires: dict[str, str | bool | list[str]] | None = None,
 ) -> t.Callable[[t.Callable[P, T]], Target[P, T]]:
@@ -301,14 +301,14 @@ def workflow(
     *,
     name: str | None = None,
     wait: bool | t.Iterable[str] | str = False,
-    cache: bool | int | float | dt.timedelta = False,
+    cache: bool | float | dt.timedelta = False,
     cache_params: t.Iterable[str] | str | None = None,
     cache_namespace: str | None = None,
     cache_version: str | None = None,
     retries: int | tuple[int, int] | tuple[int, int, int] = 0,
     defer: bool = False,
     defer_params: t.Iterable[str] | str | None = None,
-    delay: int | float | dt.timedelta = 0,
+    delay: float | dt.timedelta = 0,
     requires: dict[str, str | bool | list[str]] | None = None,
 ) -> t.Callable[[t.Callable[P, T]], Target[P, T]]:
     def decorator(fn: t.Callable[P, T]) -> Target[P, T]:
@@ -337,14 +337,14 @@ def stub(
     name: str | None = None,
     type: t.Literal["workflow", "task"] = "task",
     wait: bool | t.Iterable[str] | str = False,
-    cache: bool | int | float | dt.timedelta = False,
+    cache: bool | float | dt.timedelta = False,
     cache_params: t.Iterable[str] | str | None = None,
     cache_namespace: str | None = None,
     cache_version: str | None = None,
     retries: int | tuple[int, int] | tuple[int, int, int] = 0,
     defer: bool = False,
     defer_params: t.Iterable[str] | str | None = None,
-    delay: int | float | dt.timedelta = 0,
+    delay: float | dt.timedelta = 0,
     memo: bool | t.Iterable[str] = False,
 ) -> t.Callable[[t.Callable[P, T]], Target[P, T]]:
     def decorator(fn: t.Callable[P, T]) -> Target[P, T]:

--- a/clients/python/coflux/models.py
+++ b/clients/python/coflux/models.py
@@ -14,7 +14,7 @@ class Parameter(t.NamedTuple):
 
 class Cache(t.NamedTuple):
     params: list[int] | t.Literal[True]
-    max_age: int | float | None
+    max_age: float | None
     namespace: str | None
     version: str | None
 
@@ -38,7 +38,7 @@ class Target(t.NamedTuple):
     wait_for: set[int]
     cache: Cache | None
     defer: Defer | None
-    delay: int | float
+    delay: float
     retries: Retries | None
     memo: list[int] | bool
     requires: Requires | None

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -209,6 +209,24 @@ defmodule Coflux.Handlers.Agent do
           {[{:close, 4000, "execution_invalid"}], nil}
         end
 
+      "suspend" ->
+        # TODO: also support specifying asset dependencies?
+        [execution_id, dependency_ids] = message["params"]
+        # TODO: validate dependency_ids
+
+        if is_recognised_execution?(execution_id, state) do
+          :ok =
+            Orchestration.record_result(
+              state.project_id,
+              execution_id,
+              {:suspended, dependency_ids}
+            )
+
+          {[], state}
+        else
+          {[{:close, 4000, "execution_invalid"}], nil}
+        end
+
       "get_result" ->
         [execution_id, from_execution_id] = message["params"]
 
@@ -454,6 +472,7 @@ defmodule Coflux.Handlers.Agent do
       {:value, value} -> ["value", compose_value(value)]
       {:abandoned, nil} -> ["abandoned"]
       :cancelled -> ["cancelled"]
+      :suspended -> ["suspended"]
     end
   end
 

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -68,7 +68,7 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:record_result, execution_id, result})
   end
 
-  def get_result(project_id, execution_id, from_execution_id \\ nil, session_id, request_id) do
+  def get_result(project_id, execution_id, from_execution_id, session_id, request_id) do
     call_server(
       project_id,
       {:get_result, execution_id, from_execution_id, session_id, request_id}

--- a/server/lib/coflux/orchestration/results.ex
+++ b/server/lib/coflux/orchestration/results.ex
@@ -92,6 +92,9 @@ defmodule Coflux.Orchestration.Results do
 
           {:deferred, defer_id} ->
             {4, nil, nil, defer_id}
+
+          {:suspended, successor_id} ->
+            {6, nil, nil, successor_id}
         end
 
       case insert_result(db, execution_id, type, error_id, value_id, successor_id, now) do
@@ -146,6 +149,9 @@ defmodule Coflux.Orchestration.Results do
 
             {5, nil, nil, cached_id} ->
               {:cached, cached_id}
+
+            {6, nil, nil, successor_id} ->
+              {:suspended, successor_id}
           end
 
         {:ok, {result, created_at}}

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -367,6 +367,9 @@ defmodule Coflux.Topics.Run do
       {:cached, execution_id, execution} ->
         %{type: "cached", executionId: execution_id, execution: build_execution(execution)}
 
+      {:suspended, successor_id} ->
+        %{type: "suspended", successorId: successor_id}
+
       nil ->
         nil
     end

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -350,6 +350,7 @@ CREATE TABLE results (
       WHEN 3 THEN NOT (error_id OR successor_id OR value_id)
       WHEN 4 THEN successor_id AND NOT (error_id OR value_id)
       WHEN 5 THEN successor_id AND NOT (error_id OR value_id)
+      WHEN 6 THEN successor_id AND NOT (error_id OR value_id)
       ELSE FALSE
     END
   )

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -34,6 +34,8 @@ function classNameForExecution(execution: models.Execution) {
     return "border-red-400 bg-red-100";
   } else if (result.type == "abandoned" || result.type == "cancelled") {
     return "border-yellow-400 bg-yellow-100";
+  } else if (result.type == "suspended") {
+    return "border-yellow-200 bg-yellow-50";
   } else {
     return "border-slate-400 bg-slate-100";
   }

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -71,6 +71,8 @@ function ExecutionStatus({ execution }: ExecutionStatusProps) {
     <Badge intent="danger" label="Failed" />
   ) : execution.result?.type == "abandoned" ? (
     <Badge intent="warning" label="Abandoned" />
+  ) : execution.result?.type == "suspended" ? (
+    <Badge intent="warning" label="Suspended" />
   ) : execution.result?.type == "cancelled" ? (
     <Badge intent="warning" label="Cancelled" />
   ) : !execution.assignedAt ? (
@@ -1232,6 +1234,7 @@ export default function StepDetail({
           ) : execution?.result?.type == "cached" ? (
             <CachedSection result={execution.result} />
           ) : undefined}
+          {/* TODO: 'suspended' section? */}
           {execution && Object.keys(execution.assets).length > 0 && (
             <AssetsSection execution={execution} projectId={projectId} />
           )}

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -117,7 +117,8 @@ export type Result =
   | { type: "abandoned"; retryId: string | null }
   | { type: "cancelled" }
   | { type: "deferred"; executionId: string; execution: Reference }
-  | { type: "cached"; executionId: string; execution: Reference };
+  | { type: "cached"; executionId: string; execution: Reference }
+  | { type: "suspended"; successorId: string };
 
 export type Child = {
   repository: string;


### PR DESCRIPTION
This adds an initial implementation of 'suspense'. A task/workflow can use a context manager to impose a timeout on the wait to resolve a result. If the result takes longer to resolve than the timeout, the task will be suspended and restarted once the result is available. It's important that anything up to the end of the suspense is idempotent, since it will be re-executed in the case of a timeout. In this current form this is a bit of a foot-gun, because if the task being called isn't memo-ised, a new task will be scheduled when the workflow restarts, likely leading to repeatedly suspending.

```python
@cf.task(memo=True):
def slow_task():
    time.sleep(10)

@cf.workflow():
def suspense_workflow():
    with cf.suspense(2):
        slow_task()
```

In the example above, `slow_task` will be called, then after two seconds the workflow will suspend, then it will be re-started once `slow_task` has completed (eight seconds later).