### PR TITLE
Suspend

### DIFF
--- a/clients/python/coflux/__init__.py
+++ b/clients/python/coflux/__init__.py
@@ -2,6 +2,7 @@ from .decorators import workflow, task, stub, sensor
 from .context import (
     checkpoint,
     suspense,
+    suspend,
     persist_asset,
     restore_asset,
     log_debug,
@@ -19,6 +20,7 @@ __all__ = [
     "sensor",
     "checkpoint",
     "suspense",
+    "suspend",
     "log_debug",
     "log_info",
     "log_warning",

--- a/clients/python/coflux/context.py
+++ b/clients/python/coflux/context.py
@@ -51,6 +51,10 @@ def suspense(timeout: float | None):
     return _get_channel().suspense(timeout)
 
 
+def suspend(delay: float | dt.datetime | None = None):
+    return _get_channel().suspend(delay)
+
+
 def persist_asset(
     path: Path | str | None = None, *, match: str | None = None
 ) -> models.Asset:

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -211,7 +211,8 @@ defmodule Coflux.Handlers.Agent do
 
       "suspend" ->
         # TODO: also support specifying asset dependencies?
-        [execution_id, dependency_ids] = message["params"]
+        [execution_id, execute_after, dependency_ids] = message["params"]
+        # TODO: validate execute_after
         # TODO: validate dependency_ids
 
         if is_recognised_execution?(execution_id, state) do
@@ -219,7 +220,7 @@ defmodule Coflux.Handlers.Agent do
             Orchestration.record_result(
               state.project_id,
               execution_id,
-              {:suspended, dependency_ids}
+              {:suspended, execute_after, dependency_ids}
             )
 
           {[], state}

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1694,13 +1694,16 @@ defmodule Coflux.Orchestration.Server do
 
         {retry_id, state} =
           cond do
-            match?({:suspended, _}, result) ->
-              {:suspended, dependency_ids} = result
+            match?({:suspended, _, _}, result) ->
+              {:suspended, execute_after, dependency_ids} = result
 
               # TODO: limit the number of times a step can suspend?
 
               {:ok, retry_id, _, state} =
-                rerun_step(state, step, environment_id, dependency_ids: dependency_ids)
+                rerun_step(state, step, environment_id,
+                  execute_after: execute_after,
+                  dependency_ids: dependency_ids
+                )
 
               state = abort_execution(state, execution_id)
 
@@ -1761,7 +1764,7 @@ defmodule Coflux.Orchestration.Server do
           case result do
             {:error, type, message, frames} -> {:error, type, message, frames, retry_id}
             :abandoned -> {:abandoned, retry_id}
-            {:suspended, _} -> {:suspended, retry_id}
+            {:suspended, _, _} -> {:suspended, retry_id}
             other -> other
           end
 

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -35,7 +35,7 @@ function classNameForExecution(execution: models.Execution) {
   } else if (result.type == "abandoned" || result.type == "cancelled") {
     return "border-yellow-400 bg-yellow-100";
   } else if (result.type == "suspended") {
-    return "border-yellow-200 bg-yellow-50";
+    return "border-slate-200 bg-slate-50";
   } else {
     return "border-slate-400 bg-slate-100";
   }

--- a/server/src/components/RunTimeline.tsx
+++ b/server/src/components/RunTimeline.tsx
@@ -61,7 +61,10 @@ function Bar({ x1, x2, x0, d, className, style }: BarProps) {
   const width = x2.diff(x1).toMillis() / d;
   return (
     <div
-      className={classNames("absolute h-full rounded -ml-2", className)}
+      className={classNames(
+        "absolute h-full rounded-full -ml-2 border border-white",
+        className,
+      )}
       style={{
         ...style,
         left: percentage(left),
@@ -122,24 +125,7 @@ export default function RunTimeline({ runId, run }: Props) {
     (id) => run.steps[id].createdAt,
   );
   return (
-    <div className="px-4">
-      <div className="flex text-slate-400 text-sm sticky top-0 z-10">
-        <div className="w-40"></div>
-        <div className="flex-1 ml-2 flex border-x border-slate-200 px-1 py-2 bg-white/90">
-          <div className="flex-1">
-            {earliestTime.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)}
-          </div>
-          <div>
-            <span
-              title={latestTime.toLocaleString(
-                DateTime.DATETIME_FULL_WITH_SECONDS,
-              )}
-            >
-              +{formatDiff(elapsedDiff)}
-            </span>
-          </div>
-        </div>
-      </div>
+    <div className="p-4">
       {stepIds.map((stepId) => {
         const step = run.steps[stepId];
         const latestAttempt = max(
@@ -168,17 +154,16 @@ export default function RunTimeline({ runId, run }: Props) {
             </div>
             <div className="flex-1 flex ml-2 pl-3 pr-1 border-x border-slate-200">
               <div className="flex-1 flex items-center">
-                <div className="flex-1 relative h-2">
+                <div className="flex-1 relative h-3">
                   <Bar
                     x1={stepTimes[stepId]}
                     x2={stepFinishedAt}
                     x0={earliestTime}
                     d={totalMillis}
-                    style={{ boxShadow: "inset 0 0 3px rgb(226, 232, 240)" }}
+                    style={{ boxShadow: "inset 0 0 5px rgb(226, 232, 240)" }}
                   />
-                  {Object.entries(step.executions)
-                    .reverse()
-                    .map(([attempt, execution]) => {
+                  {Object.entries(step.executions).map(
+                    ([attempt, execution]) => {
                       const [executeAt, assignedAt, resultAt] =
                         executionTimes[`${stepId}:${attempt}`];
                       return (
@@ -193,7 +178,7 @@ export default function RunTimeline({ runId, run }: Props) {
                             x2={resultAt || latestTime}
                             x0={earliestTime}
                             d={totalMillis}
-                            className="bg-slate-200"
+                            className="bg-slate-100"
                           />
                           {assignedAt && (
                             <Bar
@@ -206,13 +191,31 @@ export default function RunTimeline({ runId, run }: Props) {
                           )}
                         </StepLink>
                       );
-                    })}
+                    },
+                  )}
                 </div>
               </div>
             </div>
           </div>
         );
       })}
+      <div className="flex text-slate-400 text-sm sticky bottom-0">
+        <div className="w-40"></div>
+        <div className="flex-1 ml-2 flex border-x border-slate-200 px-2 py-3 bg-white/90">
+          <div className="flex-1">
+            {earliestTime.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)}
+          </div>
+          <div>
+            <span
+              title={latestTime.toLocaleString(
+                DateTime.DATETIME_FULL_WITH_SECONDS,
+              )}
+            >
+              +{formatDiff(elapsedDiff)}
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/server/src/components/RunTimeline.tsx
+++ b/server/src/components/RunTimeline.tsx
@@ -78,6 +78,8 @@ function classNameForResult(result: models.Result | null) {
     return "bg-green-300";
   } else if (result.type == "error") {
     return "bg-red-300";
+  } else if (result.type == "suspended") {
+    return "bg-slate-300";
   } else {
     return "bg-yellow-300";
   }

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -648,13 +648,17 @@ function ArgumentsSection({ arguments_, projectId }: ArgumentsSectionProps) {
   return (
     <div>
       <h3 className="uppercase text-sm font-bold text-slate-400">Arguments</h3>
-      <ol className="list-decimal list-inside ml-1 marker:text-slate-400 marker:text-xs space-y-1">
-        {arguments_.map((argument, index) => (
-          <li key={index}>
-            <Argument argument={argument} projectId={projectId} />
-          </li>
-        ))}
-      </ol>
+      {arguments_.length > 0 ? (
+        <ol className="list-decimal list-inside ml-1 marker:text-slate-400 marker:text-xs space-y-1">
+          {arguments_.map((argument, index) => (
+            <li key={index}>
+              <Argument argument={argument} projectId={projectId} />
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="italic">None</p>
+      )}
     </div>
   );
 }
@@ -1216,12 +1220,7 @@ export default function StepDetail({
         onChange={handleTabChange}
       >
         <StepDetailTab label="Overview">
-          {step.arguments?.length > 0 && (
-            <ArgumentsSection
-              arguments_={step.arguments}
-              projectId={projectId}
-            />
-          )}
+          <ArgumentsSection arguments_={step.arguments} projectId={projectId} />
           {Object.keys(step.requires).length > 0 && (
             <RequiresSection requires={step.requires} />
           )}
@@ -1234,7 +1233,6 @@ export default function StepDetail({
           ) : execution?.result?.type == "cached" ? (
             <CachedSection result={execution.result} />
           ) : undefined}
-          {/* TODO: 'suspended' section? */}
           {execution && Object.keys(execution.assets).length > 0 && (
             <AssetsSection execution={execution} projectId={projectId} />
           )}

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -72,7 +72,7 @@ function ExecutionStatus({ execution }: ExecutionStatusProps) {
   ) : execution.result?.type == "abandoned" ? (
     <Badge intent="warning" label="Abandoned" />
   ) : execution.result?.type == "suspended" ? (
-    <Badge intent="warning" label="Suspended" />
+    <Badge intent="none" label="Suspended" />
   ) : execution.result?.type == "cancelled" ? (
     <Badge intent="warning" label="Cancelled" />
   ) : !execution.assignedAt ? (


### PR DESCRIPTION
Following on from #26 (which added support for suspending after timing out waiting for another execution), this adds support to allow an execution to explicitly suspend itself.

A delay would usually be specified with the suspend (either as a number of seconds, a `timedelta`, or a `datetime` for an explicit timestamp):

```python
@cf.workflow()
def suspend_workflow():
    if not is_ready():
        cf.suspend(60)
```