### PR TITLE
Consistent terminology

### DIFF
--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -713,7 +713,7 @@ def submit(
     _api_request(
         "POST",
         host_,
-        "schedule_workflow",
+        "submit_workflow",
         json={
             "projectId": project_,
             "environmentName": environment_,
@@ -722,7 +722,7 @@ def submit(
             "arguments": [["json", a] for a in argument],
         },
     )
-    click.secho("Workflow scheduled.", fg="green")
+    click.secho("Workflow submitted.", fg="green")
     # TODO: follow logs?
     # TODO: wait for result?
 

--- a/clients/python/coflux/context.py
+++ b/clients/python/coflux/context.py
@@ -16,7 +16,7 @@ def _get_channel() -> execution.Channel:
     return channel
 
 
-def schedule(
+def submit(
     type: t.Literal["workflow", "task"],
     repository: str,
     target: str,
@@ -31,7 +31,7 @@ def schedule(
     memo: list[int] | bool = False,
     requires: models.Requires | None = None,
 ) -> models.Execution[t.Any]:
-    return _get_channel().schedule_execution(
+    return _get_channel().submit_execution(
         type,
         repository,
         target,

--- a/clients/python/coflux/decorators.py
+++ b/clients/python/coflux/decorators.py
@@ -206,7 +206,7 @@ class Target(t.Generic[P, T]):
         definition = self._definition
         assert definition and definition.type in ("workflow", "task")
         try:
-            return context.schedule(
+            return context.submit(
                 definition.type,
                 self._repository,
                 self._name,

--- a/clients/python/coflux/execution.py
+++ b/clients/python/coflux/execution.py
@@ -87,7 +87,7 @@ class RecordErrorRequest(t.NamedTuple):
     error: Error
 
 
-class ScheduleExecutionRequest(t.NamedTuple):
+class SubmitExecutionRequest(t.NamedTuple):
     type: t.Literal["workflow", "task"]
     repository: str
     target: str
@@ -280,7 +280,7 @@ class Channel:
         # TODO: wait for confirmation?
         self._running = False
 
-    def schedule_execution(
+    def submit_execution(
         self,
         type: t.Literal["workflow", "task"],
         repository: str,
@@ -308,7 +308,7 @@ class Channel:
             serialisation.serialise(a, self._blob_store) for a in arguments
         ]
         execution_id = self._request(
-            ScheduleExecutionRequest(
+            SubmitExecutionRequest(
                 type,
                 repository,
                 target,
@@ -702,7 +702,7 @@ class Execution:
 
     def _handle_request(self, request_id, request):
         match request:
-            case ScheduleExecutionRequest(
+            case SubmitExecutionRequest(
                 type,
                 repository,
                 target,
@@ -719,7 +719,7 @@ class Execution:
                     execute_after.timestamp() * 1000
                 )
                 self._server_request(
-                    "schedule",
+                    "submit",
                     (
                         type,
                         repository,

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -59,7 +59,7 @@ defmodule Coflux.Handlers.Agent do
             {[], state}
         end
 
-      "schedule" ->
+      "submit" ->
         [
           type,
           repository,
@@ -78,7 +78,7 @@ defmodule Coflux.Handlers.Agent do
         if is_recognised_execution?(parent_id, state) do
           case type do
             "workflow" ->
-              case Orchestration.schedule_run(
+              case Orchestration.submit_workflow(
                      state.project_id,
                      repository,
                      target,
@@ -100,7 +100,7 @@ defmodule Coflux.Handlers.Agent do
               end
 
             "task" ->
-              case Orchestration.schedule_task(
+              case Orchestration.submit_task(
                      state.project_id,
                      parent_id,
                      repository,

--- a/server/lib/coflux/handlers/api.ex
+++ b/server/lib/coflux/handlers/api.ex
@@ -237,7 +237,7 @@ defmodule Coflux.Handlers.Api do
     end
   end
 
-  defp handle(req, "POST", ["schedule_workflow"]) do
+  defp handle(req, "POST", ["submit_workflow"]) do
     {:ok, arguments, errors, req} =
       read_arguments(
         req,
@@ -259,7 +259,7 @@ defmodule Coflux.Handlers.Api do
       )
 
     if Enum.empty?(errors) do
-      case Orchestration.schedule_run(
+      case Orchestration.submit_workflow(
              arguments.project_id,
              arguments.repository,
              arguments.target,
@@ -285,7 +285,7 @@ defmodule Coflux.Handlers.Api do
     end
   end
 
-  defp handle(req, "POST", ["schedule_sensor"]) do
+  defp handle(req, "POST", ["start_sensor"]) do
     {:ok, arguments, errors, req} =
       read_arguments(
         req,
@@ -302,13 +302,12 @@ defmodule Coflux.Handlers.Api do
       )
 
     if Enum.empty?(errors) do
-      case Orchestration.schedule_run(
+      case Orchestration.start_sensor(
              arguments.project_id,
              arguments.repository,
              arguments.target,
              arguments.arguments,
              environment: arguments.environment_name,
-             recurrent: true,
              requires: arguments[:requires]
            ) do
         {:ok, run_id, step_id, execution_id} ->

--- a/server/lib/coflux/handlers/assets.ex
+++ b/server/lib/coflux/handlers/assets.ex
@@ -42,7 +42,7 @@ defmodule Coflux.Handlers.Assets do
 
   defp file_asset(blob_key, metadata, req) do
     content_type = Map.get(metadata, "type") || @default_mime_type
-    stream = blob_key |> blob_path() |> File.stream!()
+    stream = blob_key |> blob_path() |> File.stream!(2048)
     stream_response(req, %{"content-type" => content_type}, stream)
   end
 

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -44,12 +44,16 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:declare_targets, session_id, targets})
   end
 
-  def schedule_run(project_id, repository, target, arguments, opts \\ []) do
-    call_server(project_id, {:schedule_run, repository, target, arguments, opts})
+  def submit_workflow(project_id, repository, target, arguments, opts \\ []) do
+    call_server(project_id, {:submit_workflow, repository, target, arguments, opts})
   end
 
-  def schedule_task(project_id, parent_id, repository, target, arguments, opts \\ []) do
-    call_server(project_id, {:schedule_task, parent_id, repository, target, arguments, opts})
+  def submit_task(project_id, parent_id, repository, target, arguments, opts \\ []) do
+    call_server(project_id, {:submit_task, parent_id, repository, target, arguments, opts})
+  end
+
+  def start_sensor(project_id, repository, target, arguments, opts \\ []) do
+    call_server(project_id, {:start_sensor, repository, target, arguments, opts})
   end
 
   def cancel_run(project_id, run_id) do

--- a/server/lib/coflux/orchestration/runs.ex
+++ b/server/lib/coflux/orchestration/runs.ex
@@ -21,7 +21,7 @@ defmodule Coflux.Orchestration.Runs do
       {:ok, run_id, external_run_id} = insert_run(db, parent_id, idempotency_key, recurrent, now)
 
       {:ok, external_step_id, execution_id, attempt, now, false, result, child_added} =
-        schedule_step(
+        do_schedule_step(
           db,
           run_id,
           parent_id,
@@ -35,8 +35,7 @@ defmodule Coflux.Orchestration.Runs do
           opts
         )
 
-      {:ok, external_run_id, external_step_id, execution_id, attempt, result, now, child_added,
-       recurrent}
+      {:ok, external_run_id, external_step_id, execution_id, attempt, result, now, child_added}
     end)
   end
 
@@ -103,7 +102,7 @@ defmodule Coflux.Orchestration.Runs do
     end
   end
 
-  def schedule_task(
+  def schedule_step(
         db,
         run_id,
         parent_id,
@@ -117,7 +116,7 @@ defmodule Coflux.Orchestration.Runs do
     now = current_timestamp()
 
     with_transaction(db, fn ->
-      schedule_step(
+      do_schedule_step(
         db,
         run_id,
         parent_id,
@@ -162,7 +161,7 @@ defmodule Coflux.Orchestration.Runs do
     :crypto.hash(:sha256, data)
   end
 
-  defp schedule_step(
+  defp do_schedule_step(
          db,
          run_id,
          parent_id,

--- a/server/src/api.ts
+++ b/server/src/api.ts
@@ -47,7 +47,7 @@ export function resumeEnvironment(projectId: string, environmentId: string) {
   return request("resume_environment", { projectId, environmentId });
 }
 
-export function scheduleWorkflow(
+export function submitWorkflow(
   projectId: string,
   repository: string,
   target: string,
@@ -73,7 +73,7 @@ export function scheduleWorkflow(
     requires: Record<string, string[]>;
   }>,
 ) {
-  return request("schedule_workflow", {
+  return request("submit_workflow", {
     ...options,
     projectId,
     repository,
@@ -83,7 +83,7 @@ export function scheduleWorkflow(
   });
 }
 
-export function scheduleSensor(
+export function startSensor(
   projectId: string,
   repository: string,
   target: string,
@@ -93,7 +93,7 @@ export function scheduleSensor(
     requires: Record<string, string[]>;
   }>,
 ) {
-  return request("schedule_sensor", {
+  return request("start_sensor", {
     ...options,
     projectId,
     repository,

--- a/server/src/components/RepositoryQueue.tsx
+++ b/server/src/components/RepositoryQueue.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
 import * as models from "../models";
-import { buildUrl, formatDiff } from "../utils";
+import { buildUrl } from "../utils";
 import { DateTime } from "luxon";
 import classNames from "classnames";
 
@@ -73,7 +73,7 @@ export default function RepositoryQueue({
                     </td>
                     <td className="text-right">
                       <span className="text-slate-400">
-                        {formatDiff(diff, true)}
+                        {diff.rescale().toHuman({ unitDisplay: "narrow" })}
                       </span>
                     </td>
                   </tr>

--- a/server/src/components/RunLogs.tsx
+++ b/server/src/components/RunLogs.tsx
@@ -9,7 +9,6 @@ import {
 } from "@tabler/icons-react";
 
 import * as models from "../models";
-import { formatDiff } from "../utils";
 
 function classForLevel(level: models.LogMessageLevel) {
   switch (level) {
@@ -141,7 +140,7 @@ export default function RunLogs({
                             DateTime.DATETIME_SHORT_WITH_SECONDS,
                           )}
                         >
-                          +{formatDiff(diff)}
+                          +{diff.rescale().toHuman({ unitDisplay: "short" })}
                         </span>
                         <span className="flex-1">
                           <span

--- a/server/src/components/RunSelector.tsx
+++ b/server/src/components/RunSelector.tsx
@@ -29,7 +29,7 @@ function getRunUrl(
 }
 
 type OptionsProps = {
-  runs: Record<string, Pick<models.Run, "createdAt">>;
+  runs: Record<string, Pick<models.Run, "createdAt">> | undefined;
   projectId: string | null;
   activeEnvironmentName: string | undefined;
   selectedRunId: string;
@@ -42,7 +42,9 @@ function Options({
   selectedRunId,
 }: OptionsProps) {
   const location = useLocation();
-  if (!Object.keys(runs).length) {
+  if (!runs) {
+    return <p className="p-2 italic text-sm">Loading...</p>;
+  } else if (!Object.keys(runs).length) {
     return (
       <p className="p-2 italic whitespace-nowrap text-sm">
         No runs in this environment
@@ -115,7 +117,7 @@ function getNextPrevious(
 type NextPreviousButtonProps = {
   projectId: string | null;
   activeEnvironmentName: string | undefined;
-  runs: Record<string, Pick<models.Run, "createdAt">>;
+  runs: Record<string, Pick<models.Run, "createdAt">> | undefined;
   currentRunId: string;
   direction: "next" | "previous";
 };
@@ -129,7 +131,9 @@ function NextPreviousButton({
 }: NextPreviousButtonProps) {
   const location = useLocation();
   // TODO: move to parent?
-  const runIds = sortBy(Object.keys(runs), (runId) => runs[runId].createdAt);
+  const runIds = runs
+    ? sortBy(Object.keys(runs), (runId) => runs[runId].createdAt)
+    : [];
   const runId = getNextPrevious(runIds, currentRunId, direction);
   const Icon = direction == "next" ? IconChevronRight : IconChevronLeft;
   const className = classNames(
@@ -161,7 +165,7 @@ function NextPreviousButton({
 }
 
 type Props = {
-  runs: Record<string, Pick<models.Run, "createdAt">>;
+  runs: Record<string, Pick<models.Run, "createdAt">> | undefined;
   projectId: string | null;
   runId: string;
   activeEnvironmentName: string | undefined;

--- a/server/src/components/RunTimeline.tsx
+++ b/server/src/components/RunTimeline.tsx
@@ -6,7 +6,6 @@ import { max, sortBy } from "lodash";
 import * as models from "../models";
 import useNow from "../hooks/useNow";
 import StepLink from "./StepLink";
-import { formatDiff } from "../utils";
 
 function loadExecutionTimes(run: models.Run): {
   [key: string]: [DateTime, DateTime | null, DateTime | null];
@@ -211,7 +210,7 @@ export default function RunTimeline({ runId, run }: Props) {
                 DateTime.DATETIME_FULL_WITH_SECONDS,
               )}
             >
-              +{formatDiff(elapsedDiff)}
+              +{elapsedDiff.rescale().toHuman({ unitDisplay: "short" })}
             </span>
           </div>
         </div>

--- a/server/src/components/SensorHeader.tsx
+++ b/server/src/components/SensorHeader.tsx
@@ -66,7 +66,7 @@ export default function SensorHeader({
     (arguments_: ["json", string][]) => {
       const configuration = sensor!.configuration!;
       return api
-        .scheduleSensor(
+        .startSensor(
           projectId,
           repository!,
           target!,

--- a/server/src/components/TargetsList.tsx
+++ b/server/src/components/TargetsList.tsx
@@ -12,7 +12,7 @@ import {
 import { DateTime } from "luxon";
 
 import * as models from "../models";
-import { buildUrl, formatDiff, pluralise } from "../utils";
+import { buildUrl, pluralise } from "../utils";
 import useNow from "../hooks/useNow";
 
 function isTargetOnline(
@@ -108,10 +108,11 @@ export default function TargetsList({
                   </h2>
                   {nextDueDiff && nextDueDiff.toMillis() < -1000 ? (
                     <span
-                      title={`Executions overdue (${formatDiff(
-                        nextDueDiff,
-                        true,
-                      )})`}
+                      title={`Executions overdue (${nextDueDiff
+                        .rescale()
+                        .toHuman({
+                          unitDisplay: "short",
+                        })})`}
                     >
                       <IconAlertCircle
                         size={16}
@@ -135,7 +136,7 @@ export default function TargetsList({
                     <span
                       title={`${pluralise(scheduled, "execution")} scheduled${
                         nextDueDiff
-                          ? ` (${formatDiff(nextDueDiff!, true)})`
+                          ? ` (${nextDueDiff.rescale().toHuman({ unitDisplay: "narrow" })})`
                           : ""
                       }`}
                     >

--- a/server/src/components/WorkflowHeader.tsx
+++ b/server/src/components/WorkflowHeader.tsx
@@ -130,14 +130,12 @@ export default function WorkflowHeader({
 
         {runId && (
           <div className="flex items-center gap-2">
-            {workflow && (
-              <RunSelector
-                runs={workflow.runs}
-                projectId={projectId}
-                runId={runId}
-                activeEnvironmentName={activeEnvironmentName}
-              />
-            )}
+            <RunSelector
+              runs={workflow?.runs}
+              projectId={projectId}
+              runId={runId}
+              activeEnvironmentName={activeEnvironmentName}
+            />
 
             {runEnvironmentId && runEnvironmentId != activeEnvironmentId && (
               <EnvironmentLabel

--- a/server/src/components/WorkflowHeader.tsx
+++ b/server/src/components/WorkflowHeader.tsx
@@ -75,7 +75,7 @@ export default function WorkflowHeader({
         ? new Date().getTime() + configuration.delay * 1000
         : null;
       return api
-        .scheduleWorkflow(
+        .submitWorkflow(
           projectId,
           repository!,
           target!,

--- a/server/src/components/common/Button.tsx
+++ b/server/src/components/common/Button.tsx
@@ -10,8 +10,8 @@ const outlineStyles = {
 const variantOutlineStyles = {
   primary: {
     true: [
-      "border-cyan-500/50 text-cyan-500 enabled:shadow-cyan-500/30",
-      "hover:text-cyan-600 hover:text-cyan-600 hover:border-cyan-500",
+      "border-cyan-400/50 text-cyan-500 enabled:shadow-cyan-500/30",
+      "hover:text-cyan-600 hover:border-cyan-500",
       "focus:ring-cyan-300",
       "disabled:border-cyan-500/20 disabled:text-cyan-500/30",
     ],
@@ -24,8 +24,8 @@ const variantOutlineStyles = {
   },
   secondary: {
     true: [
-      "border-slate-500/50 text-slate-500 enabled:shadow-slate-500/30",
-      "hover:text-slate-600 hover:text-slate-600 hover:border-slate-500",
+      "border-slate-400/50 text-slate-500 enabled:shadow-slate-500/30",
+      "hover:text-slate-600 hover:border-slate-400",
       "focus:ring-slate-300",
       "disabled:border-slate-500/20 disabled:text-slate-500/30",
     ],
@@ -38,8 +38,8 @@ const variantOutlineStyles = {
   },
   success: {
     true: [
-      "border-green-500/50 text-green-500 enabled:shadow-green-500/30",
-      "hover:text-green-600 hover:text-green-600 hover:border-green-500",
+      "border-green-400/50 text-green-500 enabled:shadow-green-500/30",
+      "hover:text-green-600 hover:border-green-500",
       "focus:ring-green-300",
       "disabled:border-green-500/20 disabled:text-green-500/30",
     ],
@@ -52,8 +52,8 @@ const variantOutlineStyles = {
   },
   warning: {
     true: [
-      "border-yellow-500/50 text-yellow-500 enabled:shadow-yellow-500/30",
-      "hover:text-yellow-600 hover:text-yellow-600 hover:border-yellow-500",
+      "border-yellow-400/50 text-yellow-500 enabled:shadow-yellow-500/30",
+      "hover:text-yellow-600 hover:border-yellow-500",
       "focus:ring-yellow-300",
       "disabled:border-yellow-500/20 disabled:text-yellow-500/30",
     ],
@@ -66,8 +66,8 @@ const variantOutlineStyles = {
   },
   danger: {
     true: [
-      "border-red-500/50 text-red-500 enabled:shadow-red-500/30",
-      "hover:text-red-600 hover:text-red-600 hover:border-red-500",
+      "border-red-400/50 text-red-500 enabled:shadow-red-500/30",
+      "hover:text-red-600 hover:border-red-500",
       "focus:ring-red-300",
       "disabled:border-red-500/20 disabled:text-red-500/30",
     ],
@@ -81,7 +81,7 @@ const variantOutlineStyles = {
 };
 
 const sizeStyles = {
-  sm: "rounded-md px-2 py-0.5 text-xs h-6",
+  sm: "rounded px-2 py-0.5 text-xs h-6",
   md: "rounded-md px-3 py-1",
   lg: "rounded-lg px-4 py-1.5 text-lg",
 };

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,5 +1,4 @@
 import { isNil, omitBy } from "lodash";
-import { Duration, DurationObjectUnits } from "luxon";
 
 export function buildUrl(
   path: string,
@@ -24,40 +23,6 @@ export function humanSize(size: number) {
     Number((size / Math.pow(1024, i)).toFixed(2)),
     ["bytes", "kB", "MB", "GB", "TB"][i],
   ].join(" ");
-}
-
-const DIFF_UNITS: Partial<Record<keyof DurationObjectUnits, string>> = {
-  days: "day",
-  hours: "hour",
-  minutes: "minute",
-  seconds: "second",
-  milliseconds: "millisecond",
-};
-
-export function formatDiff(diff: Duration, concise = false, maxParts = 2) {
-  const parts = diff.toObject();
-  const units = (Object.keys(DIFF_UNITS) as (keyof DurationObjectUnits)[])
-    .filter((unit) => unit != "milliseconds" && parts[unit])
-    .slice(0, maxParts);
-  if (units.length) {
-    return units
-      .map((unit) => {
-        const value = Math.floor(parts[unit]!);
-        if (concise) {
-          return `${value}${DIFF_UNITS[unit]![0]}`;
-        } else {
-          return pluralise(Math.floor(parts[unit]!), DIFF_UNITS[unit]!);
-        }
-      })
-      .join(", ");
-  } else {
-    const value = Math.floor(diff.toMillis());
-    if (concise) {
-      return `${value}ms`;
-    } else {
-      return pluralise(value, "millisecond");
-    }
-  }
 }
 
 export function truncatePath(path: string) {


### PR DESCRIPTION
This makes the terminology around scheduling/submitting a bit clearer and more consistent by referring to "submitting" workflows (and tasks). And separately handles the case for "starting" a sensor.

Also makes a distinction between the submitted and scheduled time in the step detail (when they're different - i.e., because a step has been deliberately delayed). And tidies up formatting of durations, and other minor style changes.

Also includes a fix for an issue with streaming (larger) assets.