### PR TITLE
Update workflow retry documentation

### DIFF
--- a/docs/docs/retries.md
+++ b/docs/docs/retries.md
@@ -4,7 +4,7 @@ A step can fail for a number of reasons. One case is where an exception is raise
 
 By default, Coflux takes a cautious _at-most-once_ approach to execution, to avoid unintentionally executing a task that might have significant side-effects more than once.
 
-The simplest way to enable retries is to specify the maximum number of attempts the task should be retried:
+The simplest way to enable retries is to specify the maximum number of attempts the task (or workflow) should be retried:
 
 ```python
 @cf.task(retries=2)
@@ -39,21 +39,3 @@ def send_notification():
 ```
 
 In this case, the first retry will happen after 300 seconds, and the fifth (and final) retry will happen 600 seconds after the fourth, with an increasing gap between each retry. So (ignoring time taken for the execution and scheduling) attempts of this task would happen at `t+0`, `t+300`, `t+675`, `t+1125`, `t+1650`, `t+2250` (i.e., the final attempt happening over half an hour after the initial attempt).
-
-## Workflow retries
-
-:::info
-Automatically retrying _workflows_ (as opposed to _tasks_) that have been manually triggered (e.g., via the UI) isn't currently supported. But retries should work as expected for workflows that have been triggered by another task (or [sensor](/sensors)).
-:::
-
-As a workaround for manually triggered workflows, consider wrapping a task:
-
-```python
-@cf.task(retries=2)
-def my_task():
-    ...
-
-@cf.workflow()
-def my_workflow():
-    return my_task()
-```


### PR DESCRIPTION
This fixes the documentation for workflow retries - workflows now support retries (and caching) in a way that's consistent with tasks.