### PR TITLE
Specify workflow configuration during CLI submit

### DIFF
--- a/examples/edge_detection/Dockerfile
+++ b/examples/edge_detection/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install -r requirements.txt
 
 ADD . /app
 
-ENTRYPOINT ["coflux", "agent.run", "app.repo"]
+ENTRYPOINT ["coflux", "agent", "app.repo"]

--- a/examples/pandas_etl/Dockerfile
+++ b/examples/pandas_etl/Dockerfile
@@ -13,4 +13,4 @@ RUN poetry install --no-interaction --no-ansi
 
 COPY . ./
 
-ENTRYPOINT ["coflux", "agent.run", "dataprocessing.repo"]
+ENTRYPOINT ["coflux", "agent", "dataprocessing.repo"]

--- a/examples/slack_bot/Dockerfile
+++ b/examples/slack_bot/Dockerfile
@@ -13,4 +13,4 @@ RUN poetry install --no-interaction --no-ansi
 
 COPY . ./
 
-ENTRYPOINT ["coflux", "agent.run", "slackbot.repo"]
+ENTRYPOINT ["coflux", "agent", "slackbot.repo"]

--- a/examples/wikipedia/Dockerfile
+++ b/examples/wikipedia/Dockerfile
@@ -10,4 +10,4 @@ RUN python -m nltk.downloader punkt
 
 ADD . /app
 
-ENTRYPOINT ["coflux", "agent.run", "wikipedia.repo"]
+ENTRYPOINT ["coflux", "agent", "wikipedia.repo"]

--- a/server/lib/coflux/handlers/api.ex
+++ b/server/lib/coflux/handlers/api.ex
@@ -254,7 +254,7 @@ defmodule Coflux.Handlers.Api do
           defer: {"defer", &parse_defer/1},
           execute_after: {"executeAfter", &parse_integer(&1, optional: true)},
           retries: {"retries", &parse_retries/1},
-          requries: {"requires", &parse_tag_set/1}
+          requires: {"requires", &parse_tag_set/1}
         }
       )
 

--- a/server/lib/coflux/handlers/api.ex
+++ b/server/lib/coflux/handlers/api.ex
@@ -237,6 +237,22 @@ defmodule Coflux.Handlers.Api do
     end
   end
 
+  defp handle(req, "GET", ["get_workflow"]) do
+    qs = :cowboy_req.parse_qs(req)
+    project_id = get_query_param(qs, "project")
+    environment_name = get_query_param(qs, "environment")
+    repository = get_query_param(qs, "repository")
+    target_name = get_query_param(qs, "target")
+
+    case Orchestration.get_workflow(project_id, environment_name, repository, target_name) do
+      {:ok, nil} ->
+        json_error_response(req, "not_found", status: 404)
+
+      {:ok, workflow} ->
+        json_response(req, compose_workflow(workflow))
+    end
+  end
+
   defp handle(req, "POST", ["submit_workflow"]) do
     {:ok, arguments, errors, req} =
       read_arguments(
@@ -823,5 +839,47 @@ defmodule Coflux.Handlers.Api do
     else
       {:error, :invalid}
     end
+  end
+
+  defp compose_workflow_cache(cache) do
+    if cache do
+      %{
+        "params" => cache.params,
+        "maxAge" => cache.max_age,
+        "namespace" => cache.namespace,
+        "version" => cache.version
+      }
+    end
+  end
+
+  defp compose_workflow_defer(defer) do
+    if defer do
+      %{"params" => defer.params}
+    end
+  end
+
+  defp compose_workflow_retries(retries) do
+    if retries do
+      %{
+        "limit" => retries.limit,
+        "delayMin" => retries.delay_min,
+        "delayMax" => retries.delay_max
+      }
+    end
+  end
+
+  defp compose_workflow(workflow) do
+    %{
+      "parameters" =>
+        Enum.map(workflow.parameters, fn {name, default, annotation} ->
+          %{"name" => name, "default" => default, "annotation" => annotation}
+        end),
+      "waitFor" => workflow.wait_for,
+      "cache" => compose_workflow_cache(workflow.cache),
+      "defer" => compose_workflow_defer(workflow.defer),
+      "delay" => workflow.delay,
+      "retries" => compose_workflow_retries(workflow.retries),
+      "requires" => workflow.requires
+    }
   end
 end

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -29,6 +29,10 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:register_manifests, environment_name, manifests})
   end
 
+  def get_workflow(project_id, environment_name, repository, target_name) do
+    call_server(project_id, {:get_workflow, environment_name, repository, target_name})
+  end
+
   def start_session(project_id, environment_name, launch_id, provides, concurrency, pid) do
     call_server(
       project_id,

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -267,6 +267,17 @@ defmodule Coflux.Orchestration.Server do
     end
   end
 
+  def handle_call({:get_workflow, environment_name, repository, target_name}, _from, state) do
+    with {:ok, environment_id, _} <- lookup_environment_by_name(state, environment_name),
+         {:ok, workflow} <-
+           Manifests.get_latest_workflow(state.db, environment_id, repository, target_name) do
+      {:reply, {:ok, workflow}, state}
+    else
+      {:error, error} ->
+        {:reply, {:error, error}, state}
+    end
+  end
+
   def handle_call(
         {:start_session, environment_name, launch_id, provides, concurrency, pid},
         _from,


### PR DESCRIPTION
This updates the `submit` CLI command to query the workflow before submitting the run so that it can pass the workflow configuration (e.g., cache configuration) that was specified during registration.