### PR TITLE
Show sensor iterations

### DIFF
--- a/server/src/App.tsx
+++ b/server/src/App.tsx
@@ -15,7 +15,7 @@ import {
   GraphPage,
   TimelinePage,
   AssetsPage,
-  RunsPage,
+  ChildrenPage,
   LogsPage,
   WorkflowPage,
   SensorPage,
@@ -75,7 +75,7 @@ export default function App() {
                   <Route path="graph" element={<GraphPage />} />
                   <Route path="timeline" element={<TimelinePage />} />
                   <Route path="assets" element={<AssetsPage />} />
-                  <Route path="runs" element={<RunsPage />} />
+                  <Route path="children" element={<ChildrenPage />} />
                   <Route path="logs" element={<LogsPage />} />
                 </Route>
               </Route>

--- a/server/src/layouts/RunLayout.tsx
+++ b/server/src/layouts/RunLayout.tsx
@@ -186,7 +186,7 @@ export default function RunLayout() {
           )}
           <div className="grow flex flex-col">
             <div className="border-b px-4">
-              {run.recurrent && <Tab page="runs">Runs</Tab>}
+              {run.recurrent && <Tab page="children">Children</Tab>}
               {!run.recurrent && <Tab page="graph">Graph</Tab>}
               {!run.recurrent && <Tab page="timeline">Timeline</Tab>}
               <Tab page="logs">Logs</Tab>

--- a/server/src/pages/ChildrenPage.tsx
+++ b/server/src/pages/ChildrenPage.tsx
@@ -1,17 +1,14 @@
 import { Fragment } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { DateTime } from "luxon";
 
 import * as models from "../models";
 import { useContext } from "../layouts/RunLayout";
-import { buildUrl } from "../utils";
 import StepLink from "../components/StepLink";
 
 export default function ChildrenPage() {
   const { run } = useContext();
-  const { project: projectId, run: runId } = useParams();
-  const [searchParams] = useSearchParams();
-  const environmentName = searchParams.get("environment") || undefined;
+  const { run: runId } = useParams();
   const initialStepId = Object.keys(run.steps).find(
     (stepId) => !run.steps[stepId].parentId,
   )!;
@@ -59,21 +56,20 @@ export default function ChildrenPage() {
                               </span>
                             </td>
                             <td>
-                              <Link
-                                to={buildUrl(
-                                  `/projects/${projectId}/runs/${child.runId}`,
-                                  {
-                                    environment: environmentName,
-                                  },
-                                )}
+                              <StepLink
+                                runId={child.runId}
+                                stepId={child.stepId}
+                                attempt={1}
+                                className="rounded text-sm ring-offset-1 px-1"
+                                hoveredClassName="ring-2 ring-slate-300"
                               >
                                 <span className="font-mono">
                                   {child.target}
                                 </span>{" "}
-                                <span className="text-slate-500 text-sm">
+                                <span className="text-slate-500 text-xs">
                                   ({child.repository})
                                 </span>
-                              </Link>
+                              </StepLink>
                             </td>
                           </tr>
                         );

--- a/server/src/pages/ChildrenPage.tsx
+++ b/server/src/pages/ChildrenPage.tsx
@@ -13,74 +13,81 @@ export default function ChildrenPage() {
     (stepId) => !run.steps[stepId].parentId,
   )!;
   const executions = run.steps[initialStepId].executions;
+  const hasChildren = Object.values(executions).some((e) =>
+    e.children.some((c) => typeof c != "string"),
+  );
   return (
     <div className="p-4">
-      <table className="w-full">
-        <tbody>
-          {Object.keys(executions)
-            .map((a) => parseInt(a, 10))
-            .sort()
-            .map((attempt) => {
-              const children = executions[attempt].children.filter(
-                (c): c is models.Child => typeof c != "string",
-              );
-              return (
-                <Fragment key={attempt}>
-                  {children.length ? (
-                    <Fragment>
-                      <tr>
-                        <td colSpan={2}>
-                          <h3 className="text-xs text-slate-400 uppercase font-semibold mt-3 mb-1">
-                            <StepLink
-                              runId={runId!}
-                              stepId={initialStepId}
-                              attempt={attempt}
-                              className="rounded ring-offset-1 px-1"
-                              activeClassName="ring-2 ring-cyan-400"
-                              hoveredClassName="ring-2 ring-slate-300"
-                            >
-                              Iteration #{attempt}
-                            </StepLink>
-                          </h3>
-                        </td>
-                      </tr>
-                      {children.map((child) => {
-                        const createdAt = DateTime.fromMillis(run.createdAt);
-                        return (
-                          <tr key={child.runId}>
-                            <td>
-                              <span className="text-sm text-slate-400">
-                                {createdAt.toLocaleString(
-                                  DateTime.DATETIME_SHORT_WITH_SECONDS,
-                                )}
-                              </span>
-                            </td>
-                            <td>
+      {hasChildren ? (
+        <table className="w-full">
+          <tbody>
+            {Object.keys(executions)
+              .map((a) => parseInt(a, 10))
+              .sort()
+              .map((attempt) => {
+                const children = executions[attempt].children.filter(
+                  (c): c is models.Child => typeof c != "string",
+                );
+                return (
+                  <Fragment key={attempt}>
+                    {children.length ? (
+                      <Fragment>
+                        <tr>
+                          <td colSpan={2}>
+                            <h3 className="text-xs text-slate-400 uppercase font-semibold mt-3 mb-1">
                               <StepLink
-                                runId={child.runId}
-                                stepId={child.stepId}
-                                attempt={1}
-                                className="rounded text-sm ring-offset-1 px-1"
+                                runId={runId!}
+                                stepId={initialStepId}
+                                attempt={attempt}
+                                className="rounded ring-offset-1 px-1"
+                                activeClassName="ring-2 ring-cyan-400"
                                 hoveredClassName="ring-2 ring-slate-300"
                               >
-                                <span className="font-mono">
-                                  {child.target}
-                                </span>{" "}
-                                <span className="text-slate-500 text-xs">
-                                  ({child.repository})
-                                </span>
+                                Iteration #{attempt}
                               </StepLink>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </Fragment>
-                  ) : null}
-                </Fragment>
-              );
-            })}
-        </tbody>
-      </table>
+                            </h3>
+                          </td>
+                        </tr>
+                        {children.map((child) => {
+                          const createdAt = DateTime.fromMillis(run.createdAt);
+                          return (
+                            <tr key={child.runId}>
+                              <td>
+                                <span className="text-sm text-slate-400">
+                                  {createdAt.toLocaleString(
+                                    DateTime.DATETIME_SHORT_WITH_SECONDS,
+                                  )}
+                                </span>
+                              </td>
+                              <td>
+                                <StepLink
+                                  runId={child.runId}
+                                  stepId={child.stepId}
+                                  attempt={1}
+                                  className="rounded text-sm ring-offset-1 px-1"
+                                  hoveredClassName="ring-2 ring-slate-300"
+                                >
+                                  <span className="font-mono">
+                                    {child.target}
+                                  </span>{" "}
+                                  <span className="text-slate-500 text-xs">
+                                    ({child.repository})
+                                  </span>
+                                </StepLink>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </Fragment>
+                    ) : null}
+                  </Fragment>
+                );
+              })}
+          </tbody>
+        </table>
+      ) : (
+        <p className="italic">None</p>
+      )}
     </div>
   );
 }

--- a/server/src/pages/ChildrenPage.tsx
+++ b/server/src/pages/ChildrenPage.tsx
@@ -7,8 +7,7 @@ import { useContext } from "../layouts/RunLayout";
 import { buildUrl } from "../utils";
 import StepLink from "../components/StepLink";
 
-// TODO: better name for page
-export default function RunsPage() {
+export default function ChildrenPage() {
   const { run } = useContext();
   const { project: projectId, run: runId } = useParams();
   const [searchParams] = useSearchParams();

--- a/server/src/pages/RunPage.tsx
+++ b/server/src/pages/RunPage.tsx
@@ -17,7 +17,7 @@ export default function RunPage() {
   const run = useRun(projectId, runId, activeEnvironmentId);
   useEffect(() => {
     if (run) {
-      const page = run.recurrent ? "runs" : "graph";
+      const page = run.recurrent ? "children" : "graph";
       navigate(
         buildUrl(
           `/projects/${projectId}/runs/${runId}/${page}`,

--- a/server/src/pages/RunsPage.tsx
+++ b/server/src/pages/RunsPage.tsx
@@ -1,58 +1,89 @@
+import { Fragment } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { DateTime } from "luxon";
-import { sortBy } from "lodash";
 
 import * as models from "../models";
 import { useContext } from "../layouts/RunLayout";
 import { buildUrl } from "../utils";
+import StepLink from "../components/StepLink";
 
 // TODO: better name for page
 export default function RunsPage() {
   const { run } = useContext();
-  const { project: projectId } = useParams();
+  const { project: projectId, run: runId } = useParams();
   const [searchParams] = useSearchParams();
   const environmentName = searchParams.get("environment") || undefined;
-  const runs = Object.values(run.steps)
-    .flatMap((s) => Object.values(s.executions))
-    .flatMap((e) => e.children)
-    .filter((c): c is models.Child => typeof c != "string")
-    .reduce<Record<string, models.Child>>(
-      (runs, child) => ({ ...runs, [child.runId]: child }),
-      {},
-    );
+  const initialStepId = Object.keys(run.steps).find(
+    (stepId) => !run.steps[stepId].parentId,
+  )!;
+  const executions = run.steps[initialStepId].executions;
   return (
     <div className="p-4">
       <table className="w-full">
         <tbody>
-          {sortBy(Object.keys(runs), (runId) => runs[runId].createdAt).map(
-            (runId: string) => {
-              const run = runs[runId];
-              const createdAt = DateTime.fromMillis(run.createdAt);
-              return (
-                <tr key={runId}>
-                  <td>
-                    <span className="text-sm text-slate-400">
-                      {createdAt.toLocaleString(
-                        DateTime.DATETIME_SHORT_WITH_SECONDS,
-                      )}
-                    </span>
-                  </td>
-                  <td>
-                    <Link
-                      to={buildUrl(`/projects/${projectId}/runs/${runId}`, {
-                        environment: environmentName,
-                      })}
-                    >
-                      <span className="font-mono">{run.target}</span>{" "}
-                      <span className="text-slate-500 text-sm">
-                        ({run.repository})
-                      </span>
-                    </Link>
-                  </td>
-                </tr>
+          {Object.keys(executions)
+            .map((a) => parseInt(a, 10))
+            .sort()
+            .map((attempt) => {
+              const children = executions[attempt].children.filter(
+                (c): c is models.Child => typeof c != "string",
               );
-            },
-          )}
+              return (
+                <Fragment key={attempt}>
+                  {children.length ? (
+                    <Fragment>
+                      <tr>
+                        <td colSpan={2}>
+                          <h3 className="text-xs text-slate-400 uppercase font-semibold mt-3 mb-1">
+                            <StepLink
+                              runId={runId!}
+                              stepId={initialStepId}
+                              attempt={attempt}
+                              className="rounded ring-offset-1 px-1"
+                              activeClassName="ring-2 ring-cyan-400"
+                              hoveredClassName="ring-2 ring-slate-300"
+                            >
+                              Iteration #{attempt}
+                            </StepLink>
+                          </h3>
+                        </td>
+                      </tr>
+                      {children.map((child) => {
+                        const createdAt = DateTime.fromMillis(run.createdAt);
+                        return (
+                          <tr key={child.runId}>
+                            <td>
+                              <span className="text-sm text-slate-400">
+                                {createdAt.toLocaleString(
+                                  DateTime.DATETIME_SHORT_WITH_SECONDS,
+                                )}
+                              </span>
+                            </td>
+                            <td>
+                              <Link
+                                to={buildUrl(
+                                  `/projects/${projectId}/runs/${child.runId}`,
+                                  {
+                                    environment: environmentName,
+                                  },
+                                )}
+                              >
+                                <span className="font-mono">
+                                  {child.target}
+                                </span>{" "}
+                                <span className="text-slate-500 text-sm">
+                                  ({child.repository})
+                                </span>
+                              </Link>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </Fragment>
+                  ) : null}
+                </Fragment>
+              );
+            })}
         </tbody>
       </table>
     </div>

--- a/server/src/pages/index.ts
+++ b/server/src/pages/index.ts
@@ -8,5 +8,5 @@ export { default as TimelinePage } from "./TimelinePage";
 export { default as WorkflowPage } from "./WorkflowPage";
 export { default as SensorPage } from "./SensorPage";
 export { default as LogsPage } from "./LogsPage";
-export { default as RunsPage } from "./RunsPage";
+export { default as ChildrenPage } from "./ChildrenPage";
 export { default as RepositoryPage } from "./RepositoryPage";


### PR DESCRIPTION
This updates the sensor page to indicate which iteration of a sensor each child run was submitted from. This gives the step details sidebar more context, and makes it a bit clearer how sensors operate.

This also renames the 'runs' page to the 'children' page.