### PR TITLE
Support cancelling executions

### DIFF
--- a/clients/python/coflux/decorators.py
+++ b/clients/python/coflux/decorators.py
@@ -220,7 +220,7 @@ class Target(t.Generic[P, T]):
         except context.NotInContextException:
             result = self._fn(*args, **kwargs)
             return (
-                models.Execution(lambda: result, None)
+                models.Execution(lambda: result, lambda: None, None)
                 if not isinstance(result, models.Execution)
                 else result
             )

--- a/clients/python/coflux/models.py
+++ b/clients/python/coflux/models.py
@@ -72,9 +72,11 @@ class Execution(t.Generic[T]):
     def __init__(
         self,
         resolve_fn: t.Callable[[], T],
+        cancel_fn: t.Callable[[], None],
         id: int | None,
     ):
         self._resolve_fn = resolve_fn
+        self._cancel_fn = cancel_fn
         self._id = id
 
     @property
@@ -83,6 +85,9 @@ class Execution(t.Generic[T]):
 
     def result(self) -> T:
         return self._resolve_fn()
+
+    def cancel(self) -> None:
+        self._cancel_fn()
 
 
 class Asset:

--- a/clients/python/coflux/serialisation.py
+++ b/clients/python/coflux/serialisation.py
@@ -202,6 +202,7 @@ class Manager:
         self,
         value: models.Value,
         resolve_fn: t.Callable[[int], t.Any],
+        cancel_fn: t.Callable[[int], None],
         restore_fn: t.Callable[[int, Path | str | None], Path],
     ) -> t.Any:
         data, references = self._get_value_data(value)
@@ -226,6 +227,7 @@ class Manager:
                             case ("execution", execution_id):
                                 return models.Execution(
                                     lambda: resolve_fn(execution_id),
+                                    lambda: cancel_fn(execution_id),
                                     execution_id,
                                 )
                             case ("asset", asset_id):

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -186,6 +186,13 @@ defmodule Coflux.Handlers.Agent do
           {[{:close, 4000, "execution_invalid"}], nil}
         end
 
+      "cancel" ->
+        [execution_id] = message["params"]
+
+        # TODO: restrict which executions can be cancelled?
+        :ok = Orchestration.cancel_execution(state.project_id, execution_id)
+        {[], state}
+
       "suspend" ->
         # TODO: also support specifying asset dependencies?
         [execution_id, execute_after, dependency_ids] = message["params"]

--- a/server/lib/coflux/handlers/api.ex
+++ b/server/lib/coflux/handlers/api.ex
@@ -362,17 +362,20 @@ defmodule Coflux.Handlers.Api do
     end
   end
 
-  defp handle(req, "POST", ["cancel_run"]) do
+  defp handle(req, "POST", ["cancel_execution"]) do
     {:ok, arguments, errors, req} =
       read_arguments(req, %{
         project_id: "projectId",
-        run_id: "runId"
+        execution_id: "executionId"
       })
 
+    # TODO: handle error? (or don't parse here?)
+    execution_id = String.to_integer(arguments.execution_id)
+
     if Enum.empty?(errors) do
-      case Orchestration.cancel_run(
+      case Orchestration.cancel_execution(
              arguments.project_id,
-             arguments.run_id
+             execution_id
            ) do
         :ok ->
           json_response(req, %{})

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -63,8 +63,8 @@ defmodule Coflux.Orchestration do
     )
   end
 
-  def cancel_run(project_id, run_id) do
-    call_server(project_id, {:cancel_run, run_id})
+  def cancel_execution(project_id, execution_id) do
+    call_server(project_id, {:cancel_execution, execution_id})
   end
 
   def rerun_step(project_id, step_id, environment_name) do

--- a/server/lib/coflux/orchestration/runs.ex
+++ b/server/lib/coflux/orchestration/runs.ex
@@ -517,7 +517,7 @@ defmodule Coflux.Orchestration.Runs do
     query(
       db,
       """
-      SELECT e.id, s.repository, a.created_at, r.created_at
+      SELECT e.id, s.parent_id, s.repository, a.created_at, r.created_at
       FROM executions AS e
       INNER JOIN steps AS s ON s.id = e.step_id
       LEFT JOIN assignments AS a ON a.execution_id = e.id

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -2016,16 +2016,16 @@ defmodule Coflux.Orchestration.Server do
           {:abandoned, execution_id} when not is_nil(execution_id) ->
             resolve_result(execution_id, db)
 
-          {:deferred, execution_id} when not is_nil(execution_id) ->
+          {:deferred, execution_id} ->
             resolve_result(execution_id, db)
 
-          {:cached, execution_id} when not is_nil(execution_id) ->
+          {:cached, execution_id} ->
             resolve_result(execution_id, db)
 
-          {:suspended, execution_id} when not is_nil(execution_id) ->
+          {:suspended, execution_id} ->
             resolve_result(execution_id, db)
 
-          {:spawned, execution_id} when not is_nil(execution_id) ->
+          {:spawned, execution_id} ->
             resolve_result(execution_id, db)
 
           other ->

--- a/server/src/api.ts
+++ b/server/src/api.ts
@@ -141,8 +141,8 @@ export function rerunStep(
   return post("rerun_step", { projectId, stepId, environmentName });
 }
 
-export function cancelRun(projectId: string, runId: string) {
-  return post("cancel_run", { projectId, runId });
+export function cancelExecution(projectId: string, executionId: string) {
+  return post("cancel_execution", { projectId, executionId });
 }
 
 export function search(

--- a/server/src/components/SearchInput.tsx
+++ b/server/src/components/SearchInput.tsx
@@ -70,7 +70,7 @@ function MatchOption({ icon: Icon, name, hint, href }: MatchOptionProps) {
 }
 
 function buildRunUrl(projectId: string, environmentName: string, run: Run) {
-  return `/projects/${projectId}/runs/${run.runId}/graph?environment=${environmentName}&step=${run.stepId}&attempt=${run.attempt}`;
+  return `/projects/${projectId}/runs/${run.runId}?environment=${environmentName}&step=${run.stepId}&attempt=${run.attempt}`;
 }
 
 type Props = {

--- a/server/src/components/SensorHeader.tsx
+++ b/server/src/components/SensorHeader.tsx
@@ -97,7 +97,6 @@ export default function SensorHeader({
     );
   const latestExecutionId =
     run && run.steps[initialStepId!].executions[latestAttempt!].executionId;
-  console.log("*b", initialStepId, latestAttempt, latestExecutionId);
   const handleStop = useCallback(() => {
     if (latestExecutionId) {
       return api.cancelExecution(projectId, latestExecutionId);

--- a/server/src/pages/ChildrenPage.tsx
+++ b/server/src/pages/ChildrenPage.tsx
@@ -45,24 +45,24 @@ export default function ChildrenPage() {
                 const spawned = findSpawned(run, executions[attempt]);
                 return (
                   <Fragment key={attempt}>
+                    <tr>
+                      <td colSpan={3}>
+                        <h3 className="text-xs text-slate-400 uppercase font-semibold mt-3 mb-1">
+                          <StepLink
+                            runId={runId!}
+                            stepId={initialStepId}
+                            attempt={attempt}
+                            className="rounded ring-offset-1 px-1"
+                            activeClassName="ring-2 ring-cyan-400"
+                            hoveredClassName="ring-2 ring-slate-300"
+                          >
+                            Iteration #{attempt}
+                          </StepLink>
+                        </h3>
+                      </td>
+                    </tr>
                     {spawned.length ? (
                       <Fragment>
-                        <tr>
-                          <td colSpan={3}>
-                            <h3 className="text-xs text-slate-400 uppercase font-semibold mt-3 mb-1">
-                              <StepLink
-                                runId={runId!}
-                                stepId={initialStepId}
-                                attempt={attempt}
-                                className="rounded ring-offset-1 px-1"
-                                activeClassName="ring-2 ring-cyan-400"
-                                hoveredClassName="ring-2 ring-slate-300"
-                              >
-                                Iteration #{attempt}
-                              </StepLink>
-                            </h3>
-                          </td>
-                        </tr>
                         {sortBy(
                           spawned,
                           ([stepId, attempt]) =>


### PR DESCRIPTION
This adds support for cancelling an execution - for example:

```python
@cf.task()
def my_task():
    execution = my_other_task.submit()
    # ...
    execution.cancel()
```

This will cancel the execution and all children (recursively) - but only within the run. A special case is in place to handle directly cancelling a 'spawned' run (either a workflow or a sensor) - in this case it's the spawned run that will be cancelled.