### PR TITLE
Show spawned/etc results

### DIFF
--- a/server/lib/coflux/topics/logs.ex
+++ b/server/lib/coflux/topics/logs.ex
@@ -58,7 +58,7 @@ defmodule Coflux.Topics.Logs do
 
   defp process_notification(
          topic,
-         {:step, _, _, _, _, _, _, _, _, _, execution_id, environment_id, _}
+         {:step, _, _, _, _, _, _, _, _, _, _, execution_id, environment_id, _}
        ) do
     if environment_id in topic.state.environment_ids do
       update_in(topic.state.execution_ids, &MapSet.put(&1, execution_id))

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -12,8 +12,10 @@ import {
   IconArrowUpRight,
   IconBolt,
   IconClock,
-  IconPinned,
   IconArrowDownRight,
+  IconZzz,
+  IconArrowBounce,
+  IconPin,
 } from "@tabler/icons-react";
 
 import * as models from "../models";
@@ -120,14 +122,6 @@ function StepNode({
               >
                 {step.target}
               </span>
-              {step.isMemoised && (
-                <span
-                  className="text-slate-500"
-                  title="This execution has been memoised"
-                >
-                  <IconPinned size={12} />
-                </span>
-              )}
               {execution && execution.environmentId != runEnvironmentId && (
                 <EnvironmentLabel
                   projectId={projectId}
@@ -140,11 +134,23 @@ function StepNode({
             </span>
           </span>
         </span>
-        {execution && !execution.result && !execution.assignedAt && (
-          <span>
-            <IconClock size={20} strokeWidth={1.5} />
+        {execution && !execution.result && !execution.assignedAt ? (
+          <span title="Assigning...">
+            <IconClock size={16} />
           </span>
-        )}
+        ) : execution?.result?.type == "suspended" ? (
+          <span title="Suspended">
+            <IconZzz size={16} className="text-slate-500" />
+          </span>
+        ) : execution?.result?.type == "deferred" ? (
+          <span title="Deferred">
+            <IconArrowBounce size={16} className="text-slate-400" />
+          </span>
+        ) : step.isMemoised ? (
+          <span title="Memoised">
+            <IconPin size={16} className="text-slate-500" />
+          </span>
+        ) : null}
       </StepLink>
     </Fragment>
   );

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -26,10 +26,16 @@ import { truncatePath } from "../utils";
 import AssetLink from "./AssetLink";
 
 function classNameForExecution(execution: models.Execution) {
-  const result = execution.result;
+  const result =
+    execution.result?.type == "deferred" ||
+    execution.result?.type == "cached" ||
+    execution.result?.type == "spawned"
+      ? execution.result.result
+      : execution.result;
   if (result?.type == "cached" || result?.type == "deferred") {
     return "border-slate-200 bg-slate-50";
   } else if (!result && !execution?.assignedAt) {
+    // TODO: handle spawned/etc case
     return "border-blue-200 bg-blue-50";
   } else if (!result) {
     return "border-blue-400 bg-blue-100";

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -24,7 +24,7 @@ import {
   IconChevronDown,
   IconChevronLeft,
   IconChevronRight,
-  IconPinned,
+  IconPin,
   IconReload,
   IconWindowMaximize,
   IconWindowMinimize,
@@ -493,7 +493,7 @@ function Header({
                     className="text-slate-500 self-center"
                     title="This execution has been memoised"
                   >
-                    <IconPinned size={16} />
+                    <IconPin size={16} />
                   </span>
                 )}
               </span>

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -972,7 +972,7 @@ function DeferredSection({ result }: DeferredSectionProps) {
   return (
     <div>
       <h3 className="uppercase text-sm font-bold text-slate-400">Deferred</h3>
-      {result.xecution && (
+      {result.execution && (
         <p>
           To:{" "}
           <StepLink

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -133,13 +133,15 @@ export type Error = {
 
 export type Result =
   | { type: "value"; value: Value }
-  | { type: "error"; error: Error; retryId: string | null }
-  | { type: "abandoned"; retryId: string | null }
+  | { type: "error"; error: Error; retry: number | null }
+  | { type: "abandoned"; retry: number | null }
   | { type: "cancelled" }
-  | { type: "deferred"; executionId: string; execution: ExecutionReference }
-  | { type: "cached"; executionId: string; execution: ExecutionReference }
-  | { type: "suspended"; successorId: string }
-  | { type: "spawned"; executionId: string; execution: ExecutionReference };
+  | { type: "suspended"; successor: number }
+  | {
+      type: "deferred" | "cached" | "spawned";
+      execution: ExecutionReference;
+      result?: Result;
+    };
 
 export type Child = {
   repository: string;


### PR DESCRIPTION
This updates the run UI to show the result of a spawned/cached/deferred execution so that you can see the result without navigating to the associated run. This is shown in the step panel and in the graph itself (by the node colour). It also indicates when an execution has been retried (because of an error or if it was abandoned or suspended).