### PR TITLE
Indicate stale steps

### DIFF
--- a/server/lib/coflux/orchestration/runs.ex
+++ b/server/lib/coflux/orchestration/runs.ex
@@ -759,20 +759,20 @@ defmodule Coflux.Orchestration.Runs do
     end
   end
 
-  def get_execution_run_dependencies(db, execution_id) do
+  def get_result_successors(db, execution_id) do
     query(
       db,
       """
-      WITH RECURSIVE dependencies AS (
+      WITH RECURSIVE successors AS (
         SELECT ?1 AS execution_id
         UNION
         SELECT r.execution_id
-        FROM dependencies AS d
-        INNER JOIN results AS r ON r.successor_id = d.execution_id
+        FROM successors AS ss
+        INNER JOIN results AS r ON r.successor_id = ss.execution_id
       )
-      SELECT s.run_id, d.execution_id
-      FROM dependencies AS d
-      INNER JOIN executions AS e ON e.id = d.execution_id
+      SELECT s.run_id, ss.execution_id
+      FROM successors AS ss
+      INNER JOIN executions AS e ON e.id = ss.execution_id
       INNER JOIN steps AS s ON s.id = e.step_id
       """,
       {execution_id}

--- a/server/lib/coflux/orchestration/runs.ex
+++ b/server/lib/coflux/orchestration/runs.ex
@@ -353,7 +353,7 @@ defmodule Coflux.Orchestration.Runs do
       {:ok, _} =
         insert_many(
           db,
-          :result_dependencies,
+          :dependencies,
           {:execution_id, :dependency_id, :created_at},
           Enum.map(dependency_ids, &{execution_id, &1, now})
         )
@@ -399,25 +399,10 @@ defmodule Coflux.Orchestration.Runs do
     with_transaction(db, fn ->
       insert_one(
         db,
-        :result_dependencies,
+        :dependencies,
         %{
           execution_id: execution_id,
           dependency_id: dependency_id,
-          created_at: current_timestamp()
-        },
-        on_conflict: "DO NOTHING"
-      )
-    end)
-  end
-
-  def record_asset_dependency(db, execution_id, asset_id) do
-    with_transaction(db, fn ->
-      insert_one(
-        db,
-        :asset_dependencies,
-        %{
-          execution_id: execution_id,
-          asset_id: asset_id,
           created_at: current_timestamp()
         },
         on_conflict: "DO NOTHING"
@@ -703,24 +688,12 @@ defmodule Coflux.Orchestration.Runs do
     end
   end
 
-  def get_result_dependencies(db, execution_id) do
+  def get_dependencies(db, execution_id) do
     query(
       db,
       """
       SELECT dependency_id
-      FROM result_dependencies
-      WHERE execution_id = ?1
-      """,
-      {execution_id}
-    )
-  end
-
-  def get_asset_dependencies(db, execution_id) do
-    query(
-      db,
-      """
-      SELECT asset_id
-      FROM asset_dependencies
+      FROM dependencies
       WHERE execution_id = ?1
       """,
       {execution_id}

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -515,7 +515,7 @@ defmodule Coflux.Orchestration.Server do
             notify_listeners(
               state,
               {:run, run.id},
-              {:child, parent_id, external_step_id}
+              {:child, parent_id, {external_step_id, attempt}}
             )
           else
             state

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -596,16 +596,13 @@ defmodule Coflux.Orchestration.Server do
         {:ok, _other} -> execution_id
       end
 
-    {:ok, step} = Runs.get_step_for_execution(state.db, execution_id)
-    {:ok, executions} = Runs.get_run_executions(state.db, step.run_id)
-
-    executions = filter_execution_children(execution_id, executions)
+    {:ok, executions} = Runs.get_execution_descendants(state.db, execution_id)
 
     state =
       Enum.reduce(
         executions,
         state,
-        fn {execution_id, _parent_id, repository, assigned_at, completed_at}, state ->
+        fn {execution_id, repository, assigned_at, completed_at}, state ->
           if !completed_at do
             state =
               case record_and_notify_result(

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1715,7 +1715,8 @@ defmodule Coflux.Orchestration.Server do
           )
           |> notify_listeners(
             {:targets, environment_id},
-            {:step, step.repository, step.target, run.external_id, step.external_id, attempt}
+            {:step, step.repository, step.target, step.type, run.external_id, step.external_id,
+             attempt}
           )
 
         state =

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1808,10 +1808,10 @@ defmodule Coflux.Orchestration.Server do
       {:value, _} -> true
       {:abandoned, retry_id} -> is_nil(retry_id)
       :cancelled -> true
-      {:suspended, successor_id} when not is_nil(successor_id) -> true
-      {:deferred, execution_id} when not is_nil(execution_id) -> true
-      {:cached, execution_id} when not is_nil(execution_id) -> true
-      {:spawned, execution_id} when not is_nil(execution_id) -> true
+      {:suspended, _} -> false
+      {:deferred, _} -> false
+      {:cached, _} -> false
+      {:spawned, _} -> false
     end
   end
 

--- a/server/lib/coflux/topic_utils.ex
+++ b/server/lib/coflux/topic_utils.ex
@@ -51,8 +51,7 @@ defmodule Coflux.TopicUtils do
       path: asset.path,
       metadata: asset.metadata,
       blobKey: asset.blob_key,
-      size: asset.size,
-      createdAt: asset.created_at
+      size: asset.size
     }
   end
 

--- a/server/lib/coflux/topics/logs.ex
+++ b/server/lib/coflux/topics/logs.ex
@@ -78,7 +78,6 @@ defmodule Coflux.Topics.Logs do
   defp process_notification(topic, {:asset, _, _, _}), do: topic
   defp process_notification(topic, {:assigned, _}), do: topic
   defp process_notification(topic, {:result_dependency, _, _, _}), do: topic
-  defp process_notification(topic, {:asset_dependency, _, _, _, _, _}), do: topic
   defp process_notification(topic, {:child, _, _}), do: topic
   defp process_notification(topic, {:result, _, _, _}), do: topic
   defp process_notification(topic, {:log_counts, _, _}), do: topic

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -148,11 +148,9 @@ defmodule Coflux.Topics.Run do
     )
   end
 
-  defp process_notification(topic, {:child, parent_id, child}) do
-    value = build_child(child, topic.state.external_run_id)
-
+  defp process_notification(topic, {:child, parent_id, child_id}) do
     update_execution(topic, parent_id, fn topic, base_path ->
-      Topic.insert(topic, base_path ++ [:children], value)
+      Topic.insert(topic, base_path ++ [:children], child_id)
     end)
   end
 
@@ -223,7 +221,7 @@ defmodule Coflux.Topics.Run do
                         {Integer.to_string(asset_id), build_asset(asset)}
                       end),
                     dependencies: build_dependencies(execution.dependencies),
-                    children: Enum.map(execution.children, &build_child(&1, run.external_id)),
+                    children: execution.children,
                     result: build_result(execution.result),
                     logCount: execution.log_count
                   }}
@@ -292,20 +290,6 @@ defmodule Coflux.Topics.Run do
 
       nil ->
         nil
-    end
-  end
-
-  defp build_child({external_run_id, external_step_id, repository, target, type}, run_external_id) do
-    if external_run_id == run_external_id do
-      external_step_id
-    else
-      %{
-        runId: external_run_id,
-        stepId: external_step_id,
-        repository: repository,
-        target: target,
-        type: type
-      }
     end
   end
 

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -148,9 +148,11 @@ defmodule Coflux.Topics.Run do
     )
   end
 
-  defp process_notification(topic, {:child, parent_id, child_id}) do
+  defp process_notification(topic, {:child, parent_id, child}) do
+    child = build_child(child)
+
     update_execution(topic, parent_id, fn topic, base_path ->
-      Topic.insert(topic, base_path ++ [:children], child_id)
+      Topic.insert(topic, base_path ++ [:children], child)
     end)
   end
 
@@ -221,7 +223,7 @@ defmodule Coflux.Topics.Run do
                         {Integer.to_string(asset_id), build_asset(asset)}
                       end),
                     dependencies: build_dependencies(execution.dependencies),
-                    children: execution.children,
+                    children: Enum.map(execution.children, &build_child/1),
                     result: build_result(execution.result),
                     logCount: execution.log_count
                   }}
@@ -291,6 +293,10 @@ defmodule Coflux.Topics.Run do
       nil ->
         nil
     end
+  end
+
+  defp build_child({external_step_id, attempt}) do
+    %{stepId: external_step_id, attempt: attempt}
   end
 
   defp update_execution(topic, execution_id, fun) do

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -255,7 +255,7 @@ CREATE TABLE children (
   created_at INTEGER NOT NULL,
   PRIMARY KEY (parent_id, child_id),
   FOREIGN KEY (parent_id) REFERENCES executions ON DELETE CASCADE,
-  FOREIGN KEY (child_id) REFERENCES steps ON DELETE CASCADE
+  FOREIGN KEY (child_id) REFERENCES executions ON DELETE CASCADE
 );
 
 CREATE TABLE assignments (

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -266,13 +266,22 @@ CREATE TABLE assignments (
   FOREIGN KEY (session_id) REFERENCES sessions ON DELETE CASCADE
 );
 
-CREATE TABLE dependencies (
+CREATE TABLE result_dependencies (
   execution_id INTEGER NOT NULL,
   dependency_id INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
   PRIMARY KEY (execution_id, dependency_id),
   FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE,
   FOREIGN KEY (dependency_id) REFERENCES executions ON DELETE RESTRICT
+);
+
+CREATE TABLE asset_dependencies (
+  execution_id INTEGER NOT NULL,
+  asset_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (execution_id, asset_id),
+  FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE,
+  FOREIGN KEY (asset_id) REFERENCES assets ON DELETE RESTRICT
 );
 
 CREATE TABLE checkpoints(

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -314,7 +314,7 @@ CREATE TABLE serialisers (
 
 CREATE TABLE fragments (
   id INTEGER PRIMARY KEY,
-  hash BLOB NOT NULL,
+  hash BLOB NOT NULL UNIQUE,
   serialiser_id INTEGER NOT NULL,
   blob_id INTEGER NOT NULL,
   FOREIGN KEY (serialiser_id) REFERENCES serialisers ON DELETE RESTRICT,

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -224,12 +224,11 @@ CREATE TABLE executions (
 
 CREATE TABLE assets (
   id INTEGER PRIMARY KEY,
-  execution_id INTEGER NOT NULL,
+  hash BLOB NOT NULL UNIQUE,
   type INTEGER NOT NULL,
   path TEXT NOT NULL,
   blob_id INTEGER NOT NULL,
-  created_at INTEGER NOT NULL,
-  FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE
+  FOREIGN KEY (blob_id) REFERENCES blobs ON DELETE RESTRICT
 );
 
 CREATE TABLE asset_metadata (
@@ -237,6 +236,15 @@ CREATE TABLE asset_metadata (
   key TEXT NOT NULL,
   value TEXT NOT NULL,
   PRIMARY KEY (asset_id, key),
+  FOREIGN KEY (asset_id) REFERENCES assets ON DELETE CASCADE
+);
+
+CREATE TABLE execution_assets(
+  execution_id INTEGER NOT NULL,
+  asset_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (execution_id, asset_id),
+  FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE,
   FOREIGN KEY (asset_id) REFERENCES assets ON DELETE CASCADE
 );
 
@@ -258,22 +266,13 @@ CREATE TABLE assignments (
   FOREIGN KEY (session_id) REFERENCES sessions ON DELETE CASCADE
 );
 
-CREATE TABLE result_dependencies (
+CREATE TABLE dependencies (
   execution_id INTEGER NOT NULL,
   dependency_id INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
   PRIMARY KEY (execution_id, dependency_id),
   FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE,
   FOREIGN KEY (dependency_id) REFERENCES executions ON DELETE RESTRICT
-);
-
-CREATE TABLE asset_dependencies (
-  execution_id INTEGER NOT NULL,
-  asset_id INTEGER,
-  created_at INTEGER NOT NULL,
-  PRIMARY KEY (execution_id, asset_id),
-  FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE,
-  FOREIGN KEY (asset_id) REFERENCES assets ON DELETE RESTRICT
 );
 
 CREATE TABLE checkpoints(

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -235,7 +235,7 @@ function ParentNode({ parent }: ParentNodeProps) {
 
 type ChildNodeProps = {
   runId: string;
-  child: models.Child;
+  child: models.ExecutionReference;
 };
 
 function ChildNode({ runId, child }: ChildNodeProps) {

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -322,21 +322,22 @@ function ParentNode({ parent }: ParentNodeProps) {
 }
 
 type ChildNodeProps = {
-  runId: string;
   child: models.ExecutionReference;
 };
 
-function ChildNode({ runId, child }: ChildNodeProps) {
+function ChildNode({ child }: ChildNodeProps) {
   return (
     <StepLink
-      runId={runId}
+      runId={child.runId}
       stepId={child.stepId}
-      attempt={1}
+      attempt={child.attempt}
       className="flex-1 w-full h-full flex items-center px-2 py-1 border border-slate-300 rounded-full bg-white ring-offset-2"
       hoveredClassName="ring ring-slate-400"
     >
       <IconArrowUpRight size={20} className="text-slate-400" />
-      <span className="text-slate-500 font-bold flex-1 text-end">{runId}</span>
+      <span className="text-slate-500 font-bold flex-1 text-end">
+        {child.runId}
+      </span>
     </StepLink>
   );
 }
@@ -602,7 +603,7 @@ export default function RunGraph({
                   ) : node.type == "assets" ? (
                     <MoreAssetsNode assetIds={node.assetIds} />
                   ) : node.type == "child" ? (
-                    <ChildNode runId={node.runId} child={node.child} />
+                    <ChildNode child={node.child} />
                   ) : undefined}
                 </div>
               );

--- a/server/src/components/RunGraph.tsx
+++ b/server/src/components/RunGraph.tsx
@@ -17,6 +17,7 @@ import {
   IconArrowBounce,
   IconPin,
   IconAlertCircle,
+  IconStackPop,
 } from "@tabler/icons-react";
 
 import * as models from "../models";
@@ -220,6 +221,10 @@ function StepNode({
         ) : execution && !execution.result && !execution.assignedAt ? (
           <span title="Assigning...">
             <IconClock size={16} />
+          </span>
+        ) : execution?.result?.type == "cached" ? (
+          <span title="Cache read">
+            <IconStackPop size={16} className="text-slate-400" />
           </span>
         ) : execution?.result?.type == "suspended" ? (
           <span title="Suspended">

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -803,44 +803,23 @@ function RelationsSection({
       <div>
         <h3 className="uppercase text-sm font-bold text-slate-400">Children</h3>
         {execution.children.length ? (
-          <ul className="">
+          <ul>
             {execution.children.map((child) => {
-              if (typeof child == "string") {
-                const step = run.steps[child];
-                return (
-                  <li key={child}>
-                    <StepLink
-                      runId={runId}
-                      stepId={child}
-                      attempt={1}
-                      className="rounded text-sm ring-offset-1 px-1"
-                      hoveredClassName="ring-2 ring-slate-300"
-                    >
-                      <span className="font-mono">{step.target}</span>{" "}
-                      <span className="text-slate-500">
-                        ({step.repository})
-                      </span>
-                    </StepLink>
-                  </li>
-                );
-              } else {
-                return (
-                  <li key={child.stepId}>
-                    <StepLink
-                      runId={child.runId}
-                      stepId={child.stepId}
-                      attempt={1}
-                      className="rounded text-sm ring-offset-1 px-1"
-                      hoveredClassName="ring-2 ring-slate-300"
-                    >
-                      <span className="font-mono">{child.target}</span>{" "}
-                      <span className="text-slate-500">
-                        ({child.repository})
-                      </span>
-                    </StepLink>
-                  </li>
-                );
-              }
+              const step = run.steps[child];
+              return (
+                <li key={child}>
+                  <StepLink
+                    runId={runId}
+                    stepId={child}
+                    attempt={1}
+                    className="rounded text-sm ring-offset-1 px-1"
+                    hoveredClassName="ring-2 ring-slate-300"
+                  >
+                    <span className="font-mono">{step.target}</span>{" "}
+                    <span className="text-slate-500">({step.repository})</span>
+                  </StepLink>
+                </li>
+              );
             })}
           </ul>
         ) : (

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -708,15 +708,17 @@ function DependenciesSection({ execution }: DependenciesSectionProps) {
               return (
                 <li key={`r-${dependencyId}`}>
                   <StepLink
-                    runId={dependency.runId}
-                    stepId={dependency.stepId}
-                    attempt={dependency.attempt}
+                    runId={dependency.execution.runId}
+                    stepId={dependency.execution.stepId}
+                    attempt={dependency.execution.attempt}
                     className="rounded text-sm ring-offset-1 px-1"
                     hoveredClassName="ring-2 ring-slate-300"
                   >
-                    <span className="font-mono">{dependency.target}</span>{" "}
+                    <span className="font-mono">
+                      {dependency.execution.target}
+                    </span>{" "}
                     <span className="text-slate-500">
-                      ({dependency.repository})
+                      ({dependency.execution.repository})
                     </span>
                   </StepLink>
                 </li>

--- a/server/src/components/StepDetail.tsx
+++ b/server/src/components/StepDetail.tsx
@@ -805,13 +805,13 @@ function RelationsSection({
         {execution.children.length ? (
           <ul>
             {execution.children.map((child) => {
-              const step = run.steps[child];
+              const step = run.steps[child.stepId];
               return (
-                <li key={child}>
+                <li key={`${child.stepId}/${child.attempt}`}>
                   <StepLink
                     runId={runId}
-                    stepId={child}
-                    attempt={1}
+                    stepId={child.stepId}
+                    attempt={child.attempt}
                     className="rounded text-sm ring-offset-1 px-1"
                     hoveredClassName="ring-2 ring-slate-300"
                   >

--- a/server/src/components/StepLink.tsx
+++ b/server/src/components/StepLink.tsx
@@ -67,7 +67,7 @@ export default function StepLink({
       )}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
-      title={`${stepId} (${attempt})`}
+      title={`${stepId} (#${attempt})`}
     >
       {children}
     </Link>

--- a/server/src/graph.ts
+++ b/server/src/graph.ts
@@ -227,7 +227,7 @@ export default function buildGraph(
 
       Object.entries(execution.dependencies).forEach(
         ([dependencyId, dependency]) => {
-          if (dependency.runId == runId) {
+          if (dependency.execution.runId == runId) {
             if (
               !execution.children.some(
                 (c) =>
@@ -239,8 +239,8 @@ export default function buildGraph(
                   ),
               )
             ) {
-              edges[`${dependency.stepId}-${stepId}`] = {
-                from: dependency.stepId,
+              edges[`${dependency.execution.stepId}-${stepId}`] = {
+                from: dependency.execution.stepId,
                 to: stepId,
                 type: "dependency",
               };
@@ -296,7 +296,7 @@ export default function buildGraph(
               }
             } else if (
               !Object.values(execution.dependencies).some(
-                (d) => d.stepId == child,
+                (d) => d.execution.stepId == child,
               )
             ) {
               edges[`${stepId}-${child}`] = {
@@ -318,7 +318,7 @@ export default function buildGraph(
           };
           if (
             Object.values(execution.dependencies).some(
-              (d) => d.runId == child.runId,
+              (d) => d.execution.runId == child.runId,
             )
           ) {
             edges[`${child.runId}-${stepId}`] = {

--- a/server/src/graph.ts
+++ b/server/src/graph.ts
@@ -18,7 +18,6 @@ type BaseNode = (
   | {
       type: "child";
       child: models.ExecutionReference;
-      runId: string;
     }
   | {
       type: "asset";
@@ -254,52 +253,26 @@ export default function buildGraph(
         result?.type == "cached" ||
         result?.type == "spawned"
       ) {
-        const childRunId = result.execution.runId;
-        if (childRunId != runId) {
-          nodes[result.execution.runId] = {
+        if (result.execution.runId != runId) {
+          const childId = `${result.execution.runId}/${result.execution.stepId}`;
+          nodes[childId] = {
             type: "child",
             child: result.execution,
-            runId: childRunId,
             width: 100,
             height: 30,
           };
-          if (
-            Object.values(execution.dependencies).some(
-              (d) => d.execution.runId == childRunId,
-            )
-          ) {
-            edges[`${childRunId}-${stepId}`] = {
-              from: childRunId,
-              to: stepId,
-              type: "dependency",
-            };
-          } else {
-            edges[`${stepId}-${childRunId}`] = {
-              from: stepId,
-              to: childRunId,
-              type: "child",
-            };
-          }
+          edges[`${childId}-${stepId}`] = {
+            from: childId,
+            to: stepId,
+            type: "dependency",
+          };
         } else {
           const childStepId = result.execution.stepId;
-          // TODO: fix/remove this dependency check?
-          if (
-            Object.values(execution.dependencies).some(
-              (d) => d.execution.stepId == childStepId,
-            )
-          ) {
-            edges[`${childStepId}-${stepId}`] = {
-              from: childStepId,
-              to: stepId,
-              type: "dependency",
-            };
-          } else {
-            edges[`${stepId}-${childStepId}`] = {
-              from: stepId,
-              to: childStepId,
-              type: "child",
-            };
-          }
+          edges[`${childStepId}-${stepId}`] = {
+            from: childStepId,
+            to: stepId,
+            type: "dependency",
+          };
         }
       }
     },

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -140,14 +140,6 @@ export type Result =
       result?: Result;
     };
 
-export type Child = {
-  repository: string;
-  target: string;
-  type: "workflow" | "sensor";
-  runId: string;
-  stepId: string;
-};
-
 // TODO: combine with `Execution`?
 export type QueuedExecution = {
   target: string;
@@ -171,7 +163,7 @@ export type Execution = {
   assignedAt: number | null;
   completedAt: number | null;
   dependencies: Record<string, Dependency>;
-  children: (string | Child)[];
+  children: string[];
   result: Result | null;
   assets: Record<string, Asset>;
   logCount: number;

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -70,8 +70,6 @@ export type Asset = {
   blobKey: string;
   size: number;
   metadata: Record<string, any>;
-  execution?: ExecutionReference;
-  createdAt: number;
 };
 
 export type Reference =
@@ -84,7 +82,6 @@ export type Reference =
     }
   | {
       type: "execution";
-      executionId: string;
       execution: ExecutionReference;
     }
   | {
@@ -162,8 +159,8 @@ export type QueuedExecution = {
   assignedAt: number | null;
 };
 
-export type Dependency = ExecutionReference & {
-  assets: Record<string, Asset>;
+export type Dependency = {
+  execution: ExecutionReference;
 };
 
 export type Execution = {

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -155,6 +155,11 @@ export type Dependency = {
   execution: ExecutionReference;
 };
 
+export type Child = {
+  stepId: string;
+  attempt: number;
+};
+
 export type Execution = {
   executionId: string;
   environmentId: string;
@@ -163,7 +168,7 @@ export type Execution = {
   assignedAt: number | null;
   completedAt: number | null;
   dependencies: Record<string, Dependency>;
-  children: string[];
+  children: Child[];
   result: Result | null;
   assets: Record<string, Asset>;
   logCount: number;

--- a/server/src/pages/AssetsPage.tsx
+++ b/server/src/pages/AssetsPage.tsx
@@ -36,7 +36,7 @@ export default function AssetsPage() {
         ),
       ),
     ),
-    (item) => item[5].createdAt,
+    (item) => item[5].path,
   );
   return (
     <div className="p-4">

--- a/server/src/pages/ChildrenPage.tsx
+++ b/server/src/pages/ChildrenPage.tsx
@@ -108,7 +108,7 @@ export default function ChildrenPage() {
                                   <StepLink
                                     runId={child.runId}
                                     stepId={child.stepId}
-                                    attempt={1}
+                                    attempt={child.attempt}
                                     className="inline-flex items-center pl-1 pr-2 border border-slate-300 text-sm rounded-full ring-offset-1"
                                     hoveredClassName="ring-2 ring-slate-400"
                                   >


### PR DESCRIPTION
This updates the graph to indicate when a step is stale - i.e. if any of its children have been re-run and produced a different result, or are themselves stale.