### PR TITLE
Serialisation improvements

### DIFF
--- a/clients/python/coflux/config.py
+++ b/clients/python/coflux/config.py
@@ -37,7 +37,6 @@ class BlobsConfig(pydantic.BaseModel):
 
 class PandasSerialiserConfig(pydantic.BaseModel):
     type: t.Literal["pandas"] = "pandas"
-    format: str | None = None
 
 
 class PydanticSerialiserConfig(pydantic.BaseModel):

--- a/clients/python/coflux/decorators.py
+++ b/clients/python/coflux/decorators.py
@@ -127,7 +127,7 @@ def _build_definition(
     memo: bool | t.Iterable[str] | str,
     requires: dict[str, str | bool | list[str]] | None,
     is_stub: bool,
-):
+) -> models.Target:
     parameters = inspect.signature(fn).parameters.values()
     for p in parameters:
         if p.kind != inspect.Parameter.POSITIONAL_OR_KEYWORD:

--- a/clients/python/coflux/decorators.py
+++ b/clients/python/coflux/decorators.py
@@ -203,6 +203,8 @@ class Target(t.Generic[P, T]):
         return self._fn
 
     def submit(self, *args: P.args, **kwargs: P.kwargs) -> models.Execution[T]:
+        if kwargs:
+            raise Exception("Keyword arguments aren't supported - pass positional arguments instead")
         try:
             return context.submit(
                 self._definition.type,

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -387,8 +387,8 @@ defmodule Coflux.Handlers.Agent do
 
   defp parse_references(references) do
     Enum.map(references, fn
-      ["fragment", serialiser, blob_key, size, metadata] ->
-        {:fragment, serialiser, blob_key, size, metadata}
+      ["fragment", format, blob_key, size, metadata] ->
+        {:fragment, format, blob_key, size, metadata}
 
       ["execution", execution_id] ->
         {:execution, execution_id}
@@ -449,8 +449,8 @@ defmodule Coflux.Handlers.Agent do
 
   defp compose_references(references) do
     Enum.map(references, fn
-      {:fragment, serialiser, blob_key, size, metadata} ->
-        ["fragment", serialiser, blob_key, size, metadata]
+      {:fragment, format, blob_key, size, metadata} ->
+        ["fragment", format, blob_key, size, metadata]
 
       {:execution, execution_id} ->
         ["execution", execution_id]

--- a/server/lib/coflux/orchestration/runs.ex
+++ b/server/lib/coflux/orchestration/runs.ex
@@ -203,9 +203,9 @@ defmodule Coflux.Orchestration.Runs do
       [
         length(references)
         | Enum.flat_map(references, fn
-            {:fragment, serialiser, blob_key, _size, metadata} ->
+            {:fragment, format, blob_key, _size, metadata} ->
               Enum.concat(
-                [1, serialiser, blob_key],
+                [1, format, blob_key],
                 Enum.flat_map(metadata, fn {key, value} -> [key, Jason.encode!(value)] end)
               )
 

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1842,8 +1842,8 @@ defmodule Coflux.Orchestration.Server do
 
   defp resolve_references(db, references) do
     Enum.map(references, fn
-      {:fragment, serialiser, blob_key, size, metadata} ->
-        {:fragment, serialiser, blob_key, size, metadata}
+      {:fragment, format, blob_key, size, metadata} ->
+        {:fragment, format, blob_key, size, metadata}
 
       {:execution, execution_id} ->
         {:execution, execution_id, resolve_execution(db, execution_id)}
@@ -2213,7 +2213,7 @@ defmodule Coflux.Orchestration.Server do
             {:pending, _} -> false
           end
 
-        {:fragment, _serialiser, _blob_key, _size, _metadata} ->
+        {:fragment, _format, _blob_key, _size, _metadata} ->
           true
 
         {:asset, _asset_id} ->

--- a/server/lib/coflux/topic_utils.ex
+++ b/server/lib/coflux/topic_utils.ex
@@ -20,10 +20,10 @@ defmodule Coflux.TopicUtils do
 
   defp build_references(references) do
     Enum.map(references, fn
-      {:fragment, serialiser, blob_key, size, metadata} ->
+      {:fragment, format, blob_key, size, metadata} ->
         %{
           type: "fragment",
-          serialiser: serialiser,
+          format: format,
           blobKey: blob_key,
           size: size,
           metadata: metadata

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -324,7 +324,7 @@ CREATE TABLE blobs (
   size INTEGER NOT NULL
 );
 
-CREATE TABLE serialisers (
+CREATE TABLE fragment_formats (
   id INTEGER PRIMARY KEY,
   name TEXT NOT NULL UNIQUE
 );
@@ -332,9 +332,9 @@ CREATE TABLE serialisers (
 CREATE TABLE fragments (
   id INTEGER PRIMARY KEY,
   hash BLOB NOT NULL UNIQUE,
-  serialiser_id INTEGER NOT NULL,
+  format_id INTEGER NOT NULL,
   blob_id INTEGER NOT NULL,
-  FOREIGN KEY (serialiser_id) REFERENCES serialisers ON DELETE RESTRICT,
+  FOREIGN KEY (format_id) REFERENCES fragment_formats ON DELETE RESTRICT,
   FOREIGN KEY (blob_id) REFERENCES blobs ON DELETE RESTRICT
 );
 

--- a/server/src/components/Value.tsx
+++ b/server/src/components/Value.tsx
@@ -123,7 +123,7 @@ function Data({ data, references, projectId }: DataProps) {
             return (
               <Menu>
                 <MenuButton className="bg-slate-100 rounded px-1.5 py-0.5 text-xs font-sans inline-flex gap-1">
-                  {reference.serialiser}
+                  {reference.format}
                   <span className="text-slate-500">
                     ({humanSize(reference.size)})
                   </span>

--- a/server/src/models.ts
+++ b/server/src/models.ts
@@ -77,7 +77,7 @@ export type Asset = {
 export type Reference =
   | {
       type: "fragment";
-      serialiser: string;
+      format: string;
       blobKey: string;
       size: number;
       metadata: Record<string, any>;


### PR DESCRIPTION
This updates serialisation (introduced in #38), to identify fragments by a 'format', instead of the specific serialiser. This should introduce more flexibility for the future - for example being able to use different serialisers for different tasks.

This also adds a check that keyword arguments aren't being passed to tasks so that an exception is raised rather than silently ignoring them.