### PR TITLE
Make documentation sidebar scrollable

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -36,7 +36,7 @@ body {
 
 .theme-doc-sidebar-container > div {
   top: 80px;
-  height: auto;
+  height: 100%;
 }
 
 .menu__link {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -34,11 +34,6 @@ body {
   height: 2.5rem;
 }
 
-.theme-doc-sidebar-container > div {
-  top: 80px;
-  height: 100%;
-}
-
 .menu__link {
   transition: none;
 }


### PR DESCRIPTION
The left sidebar on the docs pages isn't scrollable, which means that if multiple sections are expanded it's impossible to view all nav links.

Changing the sidebar container's height from `auto` to `100%` fixes this:

| Before | After |
| --------- | ------ |
| ![image](https://github.com/user-attachments/assets/8f4dd5b3-1e55-407e-b839-4c9fd0a51379) | ![image](https://github.com/user-attachments/assets/5cf6baad-9240-4a14-80d6-7ae9b92fbeac)

