### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -134,9 +134,9 @@ def my_task():
     # ...
 ```
 
-## Environment inheritence
+## Environment inheritance
 
-The inheritence of environments effects caching - refer to [the explanation on the concepts page](/concepts#environment-inheritence).
+The inheritance of environments effects caching - refer to [the explanation on the concepts page](/concepts#environment-inheritance).
 
 ## Forcing execution
 

--- a/docs/docs/getting_started/runs.md
+++ b/docs/docs/getting_started/runs.md
@@ -25,7 +25,7 @@ You can also submit runs using the CLI:
 coflux submit hello.py print_greeting '"Joe"'
 ```
 
-(Note the need to tripple-quote the argument.)
+(Note the need to triple-quote the argument.)
 
 ## Next steps
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -10,7 +10,7 @@ It can be used to build data pipelines, coordinate background tasks, or orchestr
 
 ## Getting started
 
-The first section in this guide describes the steps involved in definining and running a workflow:
+The first section in this guide describes the steps involved in defining and running a workflow:
 
 1. Installing the Python package
 2. Starting the server

--- a/docs/docs/memoising.md
+++ b/docs/docs/memoising.md
@@ -24,7 +24,7 @@ Memoising provides several benefits for debugging:
 
 1. Memoising a task with side effects (e.g., sending a notification e-mail) means you can re-run the whole run (or part of it) without that side-effect happening.
 
-2. Memoising slow tasks allows you to fix bugs that are occuring elsewhere in the workflow.
+2. Memoising slow tasks allows you to fix bugs that are occurring elsewhere in the workflow.
 
 This is particularly useful when re-running a workflow from a production environment in a development environment (assuming the production environment is configured as an ancestor of the development environment). By liberally memo-ising tasks, specific steps can be re-run in the development environment without re-running downstream steps.
 

--- a/docs/docs/memoising.md
+++ b/docs/docs/memoising.md
@@ -16,7 +16,7 @@ Memoised steps are indicated in the web UI with a pin icon.
 
 As with caching, explicitly clicking the 're-run' button for a step will force the step to be re-run, even if it's memoised. Then subsequent memoising will use the new step execution.
 
-If a step is manually re-run in a child environment, the memoised results will be used (but memoised results from the child environment aren't availble to the parent). This follows the same rules as caching.
+If a step is manually re-run in a child environment, the memoised results will be used (but memoised results from the child environment aren't available to the parent). This follows the same rules as caching.
 
 ## For debugging
 


### PR DESCRIPTION
Couple typos I found using [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell): `cspell --locale "en-GB" "docs/docs/**/*.md"`