### PR TITLE
Update GitHub actions in docs workflow to no longer use deprecated actions/upload-artifact@v3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm run build
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build/
 
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The `docs.yml` build job [is currently failing](https://github.com/CofluxLabs/coflux/actions/runs/13144189222/job/36678310816) with the following error:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The docs workflow indirectly uses `actions/upload-artifact@v3` through `actions/upload-pages-artifact@v2`.

I've updated `actions/upload-pages-artifact` to [v3](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0) , which uses `upload-artifact@v4`.

I've also updated `actions/deploy-pages` from v2 to v4 as the `upload-pages-artifact` v3 changelog says

> To deploy a GitHub Pages site which has been uploaded with this version of actions/upload-pages-artifact, you must also use actions/deploy-pages@v4 or newer.