### PR TITLE
Support running docs workflow manually

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Docs
 on:
   push:
     paths: [docs/**]
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
This enables manually running the 'docs' Actions workflow, which should be useful for building/deploying docs in cases where they aren't run automatically (e.g., from #60).