### PR TITLE
Use Array.prototype.with instead of custom replaceAt utility

### DIFF
--- a/server/src/components/ProjectSettingsDialog.tsx
+++ b/server/src/components/ProjectSettingsDialog.tsx
@@ -17,7 +17,7 @@ import {
   MenuItem,
   MenuItems,
 } from "@headlessui/react";
-import { insertAt, removeAt, replaceAt } from "../utils";
+import { insertAt, removeAt } from "../utils";
 import Field from "./common/Field";
 import Input from "./common/Input";
 import Tabs, { Tab } from "./common/Tabs";
@@ -293,7 +293,7 @@ function BlobStoresSettings({ stores, onChange }: BlobStoresSettingsProps) {
   );
   const handleStoreChange = useCallback(
     (index: number, store: settings.BlobStoreSettings) =>
-      onChange(replaceAt(stores, index, store)),
+      onChange(stores.with(index, store)),
     [stores, onChange],
   );
   const handleStoreRemove = useCallback(

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -110,10 +110,6 @@ export function randomName(): string {
   return `${choose(adjectives)}_${choose(properNames)}`;
 }
 
-export function replaceAt<T>(array: T[], index: number, value: T): T[] {
-  return [...array.slice(0, index), value, ...array.slice(index + 1)];
-}
-
 export function removeAt<T>(array: T[], index: number) {
   return [...array.slice(0, index), ...array.slice(index + 1)];
 }


### PR DESCRIPTION
[Array.prototype.with](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with) is [supported by all modern browsers](https://caniuse.com/mdn-javascript_builtins_array_with).

We might also want to replace the implementation of `insertAt` and `removeAt` with [Array.prototype.toSpliced](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced), though JS not having labelled arguments means that `[...array.slice(0, index), ...array.slice(index + 1)]` might be easier to understand than `array.toSpliced(index, 1)` :thinking: 