### PR TITLE
Handle different device when creating blobs

### DIFF
--- a/server/lib/coflux/handlers/blobs.ex
+++ b/server/lib/coflux/handlers/blobs.ex
@@ -39,7 +39,7 @@ defmodule Coflux.Handlers.Blobs do
           if key == Base.encode16(hash, case: :lower) do
             path = blob_path(key)
             path |> Path.dirname() |> File.mkdir_p!()
-            :ok = File.rename(temp_path, path)
+            :ok = move_file(temp_path, path)
             :cowboy_req.reply(204, req)
           else
             json_error_response(req, "hash_mismatch")
@@ -67,6 +67,13 @@ defmodule Coflux.Handlers.Blobs do
               :more -> read_body(req, file, hash)
             end
         end
+    end
+  end
+
+  defp move_file(source, dest) do
+    case File.rename(source, dest) do
+      :ok -> :ok
+      {:error, :exdev} -> File.cp(source, dest)
     end
   end
 end


### PR DESCRIPTION
If the temporary directory is on a different device to the data directory, the renaming of the temporary blob file to the move it into the data directory fails. This can happen if the data directory has been mounted as Docker volume.

This change (hopefully) works around the issue by falling back to copying the file if the rename fails.