### PR TITLE
Fix CLI flags for specifying space

### DIFF
--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -882,7 +882,7 @@ def worker(
     module_name: tuple[str, ...],
 ) -> None:
     """
-    Start a worker.
+    Starts a worker.
 
     Hosts the specified modules. Paths to scripts can be passed instead of module names.
 


### PR DESCRIPTION
This updates the flag shorthand for specifying the 'space' in the CLI commands, which was missed off #88.