### PR TITLE
Support metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ def transform(data: dict) -> list:
 
 @cf.workflow()
 def my_pipeline(url: str):
-    transform(fetch_data(url))
+    return transform(fetch_data(url))
 ```
 
 Tasks and workflows are just functions — call them directly in tests, or let Coflux orchestrate them across workers.
@@ -161,7 +161,7 @@ Use the CLI to start the server:
 coflux server --no-auth
 ```
 
-Or [run it with Docker](https://docs.coflux.com/getting_started/server):
+Or [run it with Docker](https://docs.coflux.com/getting_started/server).
 
 ### 3. Create a workflow
 
@@ -200,7 +200,3 @@ coflux submit myapp/hello '"world"'
 ### 6. Open Studio
 
 Visit [studio.coflux.com](https://studio.coflux.com) and create a project with your server address (`localhost:7777`) - a Studio account isn't required. Submit workflows runs and watch them execute in real time.
-
-## License
-
-Apache 2.0

--- a/adapters/python/CHANGELOG.md
+++ b/adapters/python/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.10.0
 
-No changes.
+Enhancements:
+
+- Adds support for writing metrics, and writing progress.
 
 ## 0.9.0
 

--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -8,19 +8,15 @@ of targets.
 from __future__ import annotations
 
 import datetime as dt
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 
+from ._version import __version__
 from .decorators import task, workflow, stub
 from .target import Cache, Defer, Retries
 from .errors import ExecutionError
+from .metric import Metric, MetricGroup, MetricScale, progress
 from .models import Asset, AssetEntry, AssetMetadata, Execution
 from .state import get_context
-
-try:
-    __version__ = _pkg_version("coflux")
-except PackageNotFoundError:
-    __version__ = "dev"
 
 __all__ = [
     # Decorators
@@ -30,6 +26,9 @@ __all__ = [
     # Classes
     "Execution",
     "ExecutionError",
+    "Metric",
+    "MetricGroup",
+    "MetricScale",
     "Cache",
     "Defer",
     "Retries",
@@ -44,6 +43,7 @@ __all__ = [
     "log_info",
     "log_warning",
     "log_error",
+    "progress",
     "asset",
 ]
 

--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -19,6 +19,8 @@ from .models import Asset, AssetEntry, AssetMetadata, Execution
 from .state import get_context
 
 __all__ = [
+    # Version
+    "__version__",
     # Decorators
     "task",
     "workflow",

--- a/adapters/python/coflux/_version.py
+++ b/adapters/python/coflux/_version.py
@@ -1,0 +1,8 @@
+"""Package version, isolated to avoid circular imports."""
+
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("coflux")
+except PackageNotFoundError:
+    __version__ = "dev"

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -32,6 +32,9 @@ class ExecutorContext:
         self._pending_requests: dict[int, Any] = {}
         self._groups: list[str | None] = []
         self._working_dir = working_dir or Path.cwd()
+        self._defined_metrics: dict[str, dict] = {}
+        self._defined_scales: dict[str, dict] = {}
+        self._defined_groups: dict[str, dict] = {}
 
     def submit_execution(
         self,

--- a/adapters/python/coflux/metric.py
+++ b/adapters/python/coflux/metric.py
@@ -1,0 +1,219 @@
+"""Metric classes for recording metric data points."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator, TypeVar
+
+from . import protocol
+from .state import get_context
+
+T = TypeVar("T")
+
+
+class MetricGroup:
+    """Configuration for a metric group (shared x-axis / chart).
+
+    Args:
+        name: Group name (required). Metrics in the same group are
+            displayed together.
+        units: Optional units label for the x-axis (e.g., "epoch").
+        lower: Optional lower bound for the x-axis.
+        upper: Optional upper bound for the x-axis.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        units: str | None = None,
+        lower: float | None = None,
+        upper: float | None = None,
+    ):
+        self.name = name
+        self.units = units
+        self.lower = lower
+        self.upper = upper
+
+    def _config(self) -> dict:
+        return {"units": self.units, "lower": self.lower, "upper": self.upper}
+
+
+class MetricScale:
+    """Configuration for a metric scale (shared y-axis).
+
+    Args:
+        name: Optional scale name. Metrics sharing a scale name within a
+            group share a y-axis. Without a name, the scale is private to
+            the metric.
+        units: Optional units label for the y-axis (e.g., "%", "ms").
+        progress: Whether this scale represents progress toward ``upper``.
+        lower: Optional lower bound for the y-axis.
+        upper: Optional upper bound for the y-axis.
+    """
+
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        units: str | None = None,
+        progress: bool = False,
+        lower: float | None = None,
+        upper: float | None = None,
+    ):
+        self.name = name
+        self.units = units
+        self.progress = progress
+        self.lower = lower
+        self.upper = upper
+
+    def _config(self) -> dict:
+        return {
+            "units": self.units,
+            "progress": self.progress,
+            "lower": self.lower,
+            "upper": self.upper,
+        }
+
+
+class Metric:
+    """A metric descriptor that can record values against the current execution.
+
+    Created via ``cf.Metric(...)``. The metric definition (metadata) is lazily
+    sent to the server on the first ``record()`` call in each execution.
+    The object is serialisable and can be passed between executions.
+
+    Args:
+        key: Metric key name (e.g., "loss", "accuracy").
+        group: Optional group (str or MetricGroup). Metrics in the same group
+            are displayed together and share an x-axis.
+        scale: Optional scale (str or MetricScale). Metrics sharing a named
+            scale within a group share a y-axis. Without a scale, each metric
+            gets its own y-axis.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        *,
+        group: str | MetricGroup | None = None,
+        scale: str | MetricScale | None = None,
+    ):
+        self._key = key
+        if isinstance(group, str):
+            self._group = MetricGroup(group)
+        else:
+            self._group = group
+        if isinstance(scale, str):
+            self._scale = MetricScale(scale)
+        else:
+            self._scale = scale
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def record(self, value: float, *, at: float | None = None) -> None:
+        """Record a metric data point.
+
+        Args:
+            value: Metric value (float).
+            at: Optional x-axis value. If omitted, defaults to seconds since
+                execution start.
+        """
+        ctx = get_context()
+        self._ensure_defined(ctx)
+        protocol.send_metric(ctx.execution_id, self._key, value, at=at)
+
+    def _build_definition(self) -> dict[str, Any]:
+        definition: dict[str, Any] = {}
+        if self._group is not None:
+            definition["group"] = self._group.name
+            if self._group.units is not None:
+                definition["group_units"] = self._group.units
+            if self._group.lower is not None:
+                definition["group_lower"] = self._group.lower
+            if self._group.upper is not None:
+                definition["group_upper"] = self._group.upper
+        if self._scale is not None:
+            definition["scale"] = self._scale.name
+            if self._scale.units is not None:
+                definition["units"] = self._scale.units
+            if self._scale.progress:
+                definition["progress"] = True
+            if self._scale.lower is not None:
+                definition["lower"] = self._scale.lower
+            if self._scale.upper is not None:
+                definition["upper"] = self._scale.upper
+        return definition
+
+    def _build_config(self) -> dict:
+        return {
+            "group_name": self._group.name if self._group else None,
+            "group": self._group._config() if self._group else None,
+            "scale_name": self._scale.name if self._scale else None,
+            "scale": self._scale._config() if self._scale else None,
+        }
+
+    def _ensure_defined(self, ctx: Any) -> None:
+        config = self._build_config()
+        existing = ctx._defined_metrics.get(self._key)
+        if existing is not None:
+            if existing != config:
+                raise ValueError(
+                    f"Metric '{self._key}' already defined in this execution "
+                    f"with different configuration"
+                )
+            return
+
+        if self._group is not None:
+            group_config = self._group._config()
+            existing_group = ctx._defined_groups.get(self._group.name)
+            if existing_group is not None and existing_group != group_config:
+                raise ValueError(
+                    f"Group '{self._group.name}' already defined in this execution "
+                    f"with inconsistent configuration"
+                )
+            ctx._defined_groups[self._group.name] = group_config
+
+        if self._scale is not None and self._scale.name is not None:
+            scale_config = self._scale._config()
+            existing_scale = ctx._defined_scales.get(self._scale.name)
+            if existing_scale is not None and existing_scale != scale_config:
+                raise ValueError(
+                    f"Scale '{self._scale.name}' already defined in this execution "
+                    f"with inconsistent configuration"
+                )
+            ctx._defined_scales[self._scale.name] = scale_config
+
+        protocol.send_define_metric(
+            ctx.execution_id, self._key, self._build_definition()
+        )
+        ctx._defined_metrics[self._key] = config
+
+
+def progress(
+    iterable: Any,
+    key: str = "progress",
+    *,
+    group: str | MetricGroup | None = None,
+) -> Iterator[T]:
+    """Wrap an iterable and auto-record progress as items are consumed.
+
+    Creates a progress metric and yields each item from the iterable.
+    After each item, records the count of items consumed so far.
+
+    Args:
+        iterable: Any iterable (or sized collection) to wrap.
+        key: Metric key name. Defaults to "progress".
+        group: Optional group (str or MetricGroup).
+
+    Yields:
+        Items from the iterable.
+    """
+    if not hasattr(iterable, "__len__"):
+        iterable = list(iterable)
+    total = len(iterable)
+    m = Metric(key, group=group, scale=MetricScale(progress=True, upper=total))
+    for i, item in enumerate(iterable):
+        yield item
+        m.record(i + 1)

--- a/adapters/python/coflux/metric.py
+++ b/adapters/python/coflux/metric.py
@@ -89,6 +89,9 @@ class Metric:
         scale: Optional scale (str or MetricScale). Metrics sharing a named
             scale within a group share a y-axis. Without a scale, each metric
             gets its own y-axis.
+        throttle: Maximum data points per second for this metric. Controls
+            client-side throttling. Defaults to 10. Set to ``None`` to
+            disable throttling.
     """
 
     def __init__(
@@ -97,8 +100,10 @@ class Metric:
         *,
         group: str | MetricGroup | None = None,
         scale: str | MetricScale | None = None,
+        throttle: float | None = 10,
     ):
         self._key = key
+        self._throttle = throttle
         if isinstance(group, str):
             self._group = MetricGroup(group)
         else:
@@ -126,6 +131,8 @@ class Metric:
 
     def _build_definition(self) -> dict[str, Any]:
         definition: dict[str, Any] = {}
+        if self._throttle is not None:
+            definition["throttle"] = self._throttle
         if self._group is not None:
             definition["group"] = self._group.name
             if self._group.units is not None:

--- a/adapters/python/coflux/protocol.py
+++ b/adapters/python/coflux/protocol.py
@@ -6,7 +6,7 @@ import json
 import sys
 from typing import Any
 
-from coflux import __version__
+from ._version import __version__
 
 
 class Protocol:
@@ -342,6 +342,52 @@ def send_register_group(
             "name": name,
         },
     )
+
+
+def send_define_metric(
+    execution_id: str,
+    key: str,
+    definition: dict[str, Any],
+) -> None:
+    """Send a metric definition to the server.
+
+    Args:
+        execution_id: The execution this metric belongs to.
+        key: Metric key name.
+        definition: Definition dict with group/scale/units/progress/lower/upper.
+    """
+    get_protocol().send_message(
+        "define_metric",
+        {
+            "execution_id": execution_id,
+            "key": key,
+            "definition": definition,
+        },
+    )
+
+
+def send_metric(
+    execution_id: str,
+    key: str,
+    value: float,
+    at: float | None = None,
+) -> None:
+    """Send a metric data point.
+
+    Args:
+        execution_id: The execution this metric belongs to.
+        key: Metric key name.
+        value: Metric value (float).
+        at: Optional x-axis value. If None, the Go worker uses time-since-execution-start.
+    """
+    params: dict[str, Any] = {
+        "execution_id": execution_id,
+        "key": key,
+        "value": value,
+    }
+    if at is not None:
+        params["at"] = at
+    get_protocol().send_message("metric", params)
 
 
 def receive_message() -> dict[str, Any] | None:

--- a/cli/cmd/coflux/main.go
+++ b/cli/cmd/coflux/main.go
@@ -52,7 +52,6 @@ func init() {
 	viper.SetDefault("logs.flush_interval", 0.5)
 	viper.SetDefault("metrics.batch_size", 100)
 	viper.SetDefault("metrics.flush_interval", 0.2)
-	viper.SetDefault("metrics.throttle_rate", 10)
 	viper.SetDefault("log_level", "info")
 
 	// Global flags

--- a/cli/cmd/coflux/main.go
+++ b/cli/cmd/coflux/main.go
@@ -50,6 +50,9 @@ func init() {
 	viper.SetDefault("blobs.threshold", 100)
 	viper.SetDefault("logs.batch_size", 100)
 	viper.SetDefault("logs.flush_interval", 0.5)
+	viper.SetDefault("metrics.batch_size", 100)
+	viper.SetDefault("metrics.flush_interval", 0.2)
+	viper.SetDefault("metrics.throttle_rate", 10)
 	viper.SetDefault("log_level", "info")
 
 	// Global flags

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -12,8 +12,9 @@ type Config struct {
 	Team      string       `mapstructure:"team"`
 	Server    ServerConfig `mapstructure:"server"`
 	Worker    WorkerConfig `mapstructure:"worker"`
-	Blobs     BlobsConfig  `mapstructure:"blobs"`
-	Logs      LogsConfig   `mapstructure:"logs"`
+	Blobs     BlobsConfig   `mapstructure:"blobs"`
+	Logs      LogsConfig    `mapstructure:"logs"`
+	Metrics   MetricsConfig `mapstructure:"metrics"`
 	LogLevel  string       `mapstructure:"log_level"`
 	Output    string       `mapstructure:"output"`
 }
@@ -82,6 +83,16 @@ type LogsConfig struct {
 	URL           string  `mapstructure:"url"`
 	BatchSize     int     `mapstructure:"batch_size"`
 	FlushInterval float64 `mapstructure:"flush_interval"`
+}
+
+// MetricsConfig holds metric storage configuration
+type MetricsConfig struct {
+	Type          string  `mapstructure:"type"`
+	Token         *string `mapstructure:"token"`
+	URL           string  `mapstructure:"url"`
+	BatchSize     int     `mapstructure:"batch_size"`
+	FlushInterval float64 `mapstructure:"flush_interval"`
+	ThrottleRate  float64 `mapstructure:"throttle_rate"` // max points per key per second
 }
 
 // IsSecure determines if the connection should use TLS

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -5,18 +5,18 @@ import "strings"
 // Config represents the coflux.toml configuration file.
 // Defaults are set via viper.SetDefault() in cmd/coflux/main.go.
 type Config struct {
-	Host      string       `mapstructure:"host"`
-	Token     string       `mapstructure:"token"`
-	Secure    *bool        `mapstructure:"secure"`
-	Workspace string       `mapstructure:"workspace"`
-	Team      string       `mapstructure:"team"`
-	Server    ServerConfig `mapstructure:"server"`
-	Worker    WorkerConfig `mapstructure:"worker"`
+	Host      string        `mapstructure:"host"`
+	Token     string        `mapstructure:"token"`
+	Secure    *bool         `mapstructure:"secure"`
+	Workspace string        `mapstructure:"workspace"`
+	Team      string        `mapstructure:"team"`
+	Server    ServerConfig  `mapstructure:"server"`
+	Worker    WorkerConfig  `mapstructure:"worker"`
 	Blobs     BlobsConfig   `mapstructure:"blobs"`
 	Logs      LogsConfig    `mapstructure:"logs"`
 	Metrics   MetricsConfig `mapstructure:"metrics"`
-	LogLevel  string       `mapstructure:"log_level"`
-	Output    string       `mapstructure:"output"`
+	LogLevel  string        `mapstructure:"log_level"`
+	Output    string        `mapstructure:"output"`
 }
 
 // ServerConfig holds settings for running a local server via `coflux server`.
@@ -92,7 +92,6 @@ type MetricsConfig struct {
 	URL           string  `mapstructure:"url"`
 	BatchSize     int     `mapstructure:"batch_size"`
 	FlushInterval float64 `mapstructure:"flush_interval"`
-	ThrottleRate  float64 `mapstructure:"throttle_rate"` // max points per key per second
 }
 
 // IsSecure determines if the connection should use TLS

--- a/cli/internal/metric/http.go
+++ b/cli/internal/metric/http.go
@@ -1,0 +1,188 @@
+package metric
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HTTPStore implements Store using HTTP POST with batching
+type HTTPStore struct {
+	baseURL       string
+	token         string
+	client        *http.Client
+	batchSize     int
+	flushInterval time.Duration
+	logger        *slog.Logger
+
+	mu      sync.Mutex
+	buffer  []Entry
+	timer   *time.Timer
+	closed  bool
+	flushCh chan struct{}
+	doneCh  chan struct{}
+}
+
+// NewHTTPStore creates a new HTTP metric store
+func NewHTTPStore(baseURL string, token string, batchSize int, flushInterval time.Duration, logger *slog.Logger) *HTTPStore {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	s := &HTTPStore{
+		baseURL:       baseURL,
+		token:         token,
+		client:        &http.Client{Timeout: 30 * time.Second},
+		batchSize:     batchSize,
+		flushInterval: flushInterval,
+		logger:        logger,
+		buffer:        make([]Entry, 0, batchSize),
+		flushCh:       make(chan struct{}, 1),
+		doneCh:        make(chan struct{}),
+	}
+
+	go s.flushLoop()
+
+	return s
+}
+
+// Record writes metric entries to the buffer
+func (s *HTTPStore) Record(entries []Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return fmt.Errorf("store is closed")
+	}
+
+	s.buffer = append(s.buffer, entries...)
+
+	if len(s.buffer) >= s.batchSize || s.flushInterval == 0 {
+		s.triggerFlush()
+	} else if s.timer == nil {
+		s.timer = time.AfterFunc(s.flushInterval, func() {
+			s.mu.Lock()
+			s.timer = nil
+			s.mu.Unlock()
+			s.triggerFlush()
+		})
+	}
+
+	return nil
+}
+
+func (s *HTTPStore) triggerFlush() {
+	select {
+	case s.flushCh <- struct{}{}:
+	default:
+	}
+}
+
+func (s *HTTPStore) flushLoop() {
+	for {
+		select {
+		case <-s.flushCh:
+			s.doFlush()
+		case <-s.doneCh:
+			return
+		}
+	}
+}
+
+func (s *HTTPStore) doFlush() {
+	s.mu.Lock()
+	if len(s.buffer) == 0 {
+		s.mu.Unlock()
+		return
+	}
+
+	entries := s.buffer
+	s.buffer = make([]Entry, 0, s.batchSize)
+
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+	s.mu.Unlock()
+
+	if err := s.send(entries); err != nil {
+		s.logger.Error("failed to send metrics", "error", err, "count", len(entries))
+		s.mu.Lock()
+		s.buffer = append(entries, s.buffer...)
+		s.mu.Unlock()
+	}
+}
+
+func (s *HTTPStore) send(entries []Entry) error {
+	items := make([]map[string]any, len(entries))
+	for i, e := range entries {
+		items[i] = map[string]any{
+			"runId":       e.RunID,
+			"executionId": e.ExecutionID,
+			"workspaceId": e.WorkspaceID,
+			"key":         e.Key,
+			"value":       e.Value,
+			"at":          e.At,
+		}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"entries": items,
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if s.token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.token)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Flush sends any buffered entries
+func (s *HTTPStore) Flush() error {
+	s.doFlush()
+	return nil
+}
+
+// Close flushes and closes the store
+func (s *HTTPStore) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+	s.mu.Unlock()
+
+	s.doFlush()
+
+	close(s.doneCh)
+	return nil
+}

--- a/cli/internal/metric/store.go
+++ b/cli/internal/metric/store.go
@@ -1,0 +1,28 @@
+package metric
+
+// Entry represents a single metric data point
+type Entry struct {
+	RunID       string  // Run ID (external)
+	ExecutionID string  // Execution ID (external)
+	WorkspaceID string  // Workspace ID (external)
+	Key         string  // Metric key name
+	Value       float64 // Metric value (the y value)
+	At          float64 // X-axis value (seconds since execution start, or user-provided)
+}
+
+// Store is the interface for metric storage backends
+type Store interface {
+	// Record writes a batch of metric entries
+	Record(entries []Entry) error
+	// Flush sends any buffered entries
+	Flush() error
+	// Close flushes and closes the store
+	Close() error
+}
+
+// NoopStore is a store that discards all metrics
+type NoopStore struct{}
+
+func (NoopStore) Record(entries []Entry) error { return nil }
+func (NoopStore) Flush() error                 { return nil }
+func (NoopStore) Close() error                 { return nil }

--- a/cli/internal/metric/throttle.go
+++ b/cli/internal/metric/throttle.go
@@ -1,0 +1,186 @@
+package metric
+
+import (
+	"sync"
+	"time"
+)
+
+// Throttle wraps a Store and rate-limits metric recording per key per execution.
+// Uses a hybrid leading+trailing edge approach:
+//   - First point (or first after quiet period): sent immediately
+//   - Subsequent points within window: buffer last value, send when window closes
+//   - On flush/close: emit any buffered trailing values
+type Throttle struct {
+	inner    Store
+	window   time.Duration
+	mu       sync.Mutex
+	pending  map[throttleKey]*throttleState
+	closed   bool
+	closeCh  chan struct{}
+	flushMu  sync.Mutex
+}
+
+type throttleKey struct {
+	executionID string
+	key         string
+}
+
+type throttleState struct {
+	lastSent time.Time
+	trailing *Entry // buffered trailing-edge entry, nil if none pending
+	timer    *time.Timer
+}
+
+// NewThrottle creates a throttled store wrapper.
+// rate is max points per key per second (e.g., 10 means 100ms window).
+func NewThrottle(inner Store, rate float64) *Throttle {
+	window := time.Duration(float64(time.Second) / rate)
+	return &Throttle{
+		inner:   inner,
+		window:  window,
+		pending: make(map[throttleKey]*throttleState),
+		closeCh: make(chan struct{}),
+	}
+}
+
+// Record processes entries through the throttle
+func (t *Throttle) Record(entries []Entry) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return t.inner.Record(entries)
+	}
+
+	var toSend []Entry
+
+	for i := range entries {
+		entry := &entries[i]
+		tk := throttleKey{executionID: entry.ExecutionID, key: entry.Key}
+
+		st, exists := t.pending[tk]
+		if !exists {
+			// First point for this key — leading edge, send immediately
+			st = &throttleState{lastSent: time.Now()}
+			t.pending[tk] = st
+			toSend = append(toSend, *entry)
+			continue
+		}
+
+		elapsed := time.Since(st.lastSent)
+		if elapsed >= t.window {
+			// Quiet period exceeded window — treat as leading edge
+			st.lastSent = time.Now()
+			if st.timer != nil {
+				st.timer.Stop()
+				st.timer = nil
+			}
+			st.trailing = nil
+			toSend = append(toSend, *entry)
+		} else {
+			// Within window — buffer as trailing edge
+			entryCopy := *entry
+			st.trailing = &entryCopy
+
+			if st.timer == nil {
+				remaining := t.window - elapsed
+				st.timer = time.AfterFunc(remaining, func() {
+					t.flushTrailing(tk)
+				})
+			}
+		}
+	}
+
+	if len(toSend) > 0 {
+		return t.inner.Record(toSend)
+	}
+	return nil
+}
+
+func (t *Throttle) flushTrailing(tk throttleKey) {
+	t.mu.Lock()
+	st, exists := t.pending[tk]
+	if !exists || st.trailing == nil {
+		t.mu.Unlock()
+		return
+	}
+
+	entry := *st.trailing
+	st.trailing = nil
+	st.timer = nil
+	st.lastSent = time.Now()
+	t.mu.Unlock()
+
+	// Send outside lock
+	_ = t.inner.Record([]Entry{entry})
+}
+
+// Flush sends any buffered trailing entries and flushes the inner store
+func (t *Throttle) Flush() error {
+	t.flushMu.Lock()
+	defer t.flushMu.Unlock()
+
+	t.mu.Lock()
+	var trailing []Entry
+	for _, st := range t.pending {
+		if st.trailing != nil {
+			trailing = append(trailing, *st.trailing)
+			st.trailing = nil
+			if st.timer != nil {
+				st.timer.Stop()
+				st.timer = nil
+			}
+			st.lastSent = time.Now()
+		}
+	}
+	t.mu.Unlock()
+
+	if len(trailing) > 0 {
+		if err := t.inner.Record(trailing); err != nil {
+			return err
+		}
+	}
+
+	return t.inner.Flush()
+}
+
+// Close flushes all pending entries and closes the inner store
+func (t *Throttle) Close() error {
+	t.mu.Lock()
+	t.closed = true
+	// Stop all timers
+	for _, st := range t.pending {
+		if st.timer != nil {
+			st.timer.Stop()
+		}
+	}
+	t.mu.Unlock()
+
+	// Flush trailing entries
+	if err := t.Flush(); err != nil {
+		return err
+	}
+
+	return t.inner.Close()
+}
+
+// RemoveExecution cleans up throttle state for a finished execution
+func (t *Throttle) RemoveExecution(executionID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for tk, st := range t.pending {
+		if tk.executionID == executionID {
+			if st.timer != nil {
+				st.timer.Stop()
+			}
+			// Flush trailing entry synchronously
+			if st.trailing != nil {
+				go func(entry Entry) {
+					_ = t.inner.Record([]Entry{entry})
+				}(*st.trailing)
+			}
+			delete(t.pending, tk)
+		}
+	}
+}

--- a/cli/internal/metric/throttle.go
+++ b/cli/internal/metric/throttle.go
@@ -5,19 +5,24 @@ import (
 	"time"
 )
 
+const DefaultRate = 10.0 // default max points per key per second
+
 // Throttle wraps a Store and rate-limits metric recording per key per execution.
 // Uses a hybrid leading+trailing edge approach:
 //   - First point (or first after quiet period): sent immediately
 //   - Subsequent points within window: buffer last value, send when window closes
 //   - On flush/close: emit any buffered trailing values
+//
+// Each metric key can have its own rate, set via SetRate. Keys without
+// an explicit rate use DefaultRate.
 type Throttle struct {
-	inner    Store
-	window   time.Duration
-	mu       sync.Mutex
-	pending  map[throttleKey]*throttleState
-	closed   bool
-	closeCh  chan struct{}
-	flushMu  sync.Mutex
+	inner   Store
+	mu      sync.Mutex
+	rates   map[string]time.Duration // key -> window duration
+	pending map[throttleKey]*throttleState
+	closed  bool
+	closeCh chan struct{}
+	flushMu sync.Mutex
 }
 
 type throttleKey struct {
@@ -31,16 +36,45 @@ type throttleState struct {
 	timer    *time.Timer
 }
 
+func rateToWindow(rate float64) time.Duration {
+	if rate <= 0 {
+		rate = DefaultRate
+	}
+	return time.Duration(float64(time.Second) / rate)
+}
+
 // NewThrottle creates a throttled store wrapper.
-// rate is max points per key per second (e.g., 10 means 100ms window).
-func NewThrottle(inner Store, rate float64) *Throttle {
-	window := time.Duration(float64(time.Second) / rate)
+func NewThrottle(inner Store) *Throttle {
 	return &Throttle{
 		inner:   inner,
-		window:  window,
+		rates:   make(map[string]time.Duration),
 		pending: make(map[throttleKey]*throttleState),
 		closeCh: make(chan struct{}),
 	}
+}
+
+// SetRate sets the throttle rate for a specific metric key.
+// rate is max points per second (e.g., 10 means 100ms window).
+func (t *Throttle) SetRate(key string, rate float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.rates[key] = rateToWindow(rate)
+}
+
+// DisableRate disables throttling for a specific metric key.
+func (t *Throttle) DisableRate(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.rates[key] = 0
+}
+
+// windowFor returns the throttle window for a key.
+// Returns 0 if throttling is disabled for this key.
+func (t *Throttle) windowFor(key string) time.Duration {
+	if w, ok := t.rates[key]; ok {
+		return w
+	}
+	return rateToWindow(DefaultRate)
 }
 
 // Record processes entries through the throttle
@@ -57,6 +91,13 @@ func (t *Throttle) Record(entries []Entry) error {
 	for i := range entries {
 		entry := &entries[i]
 		tk := throttleKey{executionID: entry.ExecutionID, key: entry.Key}
+		window := t.windowFor(entry.Key)
+
+		if window == 0 {
+			// Throttling disabled for this key — pass through
+			toSend = append(toSend, *entry)
+			continue
+		}
 
 		st, exists := t.pending[tk]
 		if !exists {
@@ -68,7 +109,7 @@ func (t *Throttle) Record(entries []Entry) error {
 		}
 
 		elapsed := time.Since(st.lastSent)
-		if elapsed >= t.window {
+		if elapsed >= window {
 			// Quiet period exceeded window — treat as leading edge
 			st.lastSent = time.Now()
 			if st.timer != nil {
@@ -83,7 +124,7 @@ func (t *Throttle) Record(entries []Entry) error {
 			st.trailing = &entryCopy
 
 			if st.timer == nil {
-				remaining := t.window - elapsed
+				remaining := window - elapsed
 				st.timer = time.AfterFunc(remaining, func() {
 					t.flushTrailing(tk)
 				})

--- a/cli/internal/metric/tracker.go
+++ b/cli/internal/metric/tracker.go
@@ -1,0 +1,130 @@
+package metric
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+type atMode int
+
+const (
+	atModeUnknown atMode = iota
+	atModeAuto           // auto-computed from time since execution start
+	atModeCustom         // user-provided
+)
+
+type keyState struct {
+	mode   atMode
+	lastAt float64
+	warned bool
+}
+
+// Tracker enforces at-value consistency and auto-computes time-based at values.
+// It tracks per-execution, per-key state.
+type Tracker struct {
+	mu     sync.Mutex
+	execs  map[string]*executionTracker // executionID -> tracker
+	logger *slog.Logger
+}
+
+type executionTracker struct {
+	startTime time.Time
+	keys      map[string]*keyState
+}
+
+// NewTracker creates a new metric tracker
+func NewTracker(logger *slog.Logger) *Tracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Tracker{
+		execs:  make(map[string]*executionTracker),
+		logger: logger,
+	}
+}
+
+// RegisterExecution registers an execution with its start time.
+// Must be called before Process for that execution.
+func (t *Tracker) RegisterExecution(executionID string, startTime time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.execs[executionID] = &executionTracker{
+		startTime: startTime,
+		keys:      make(map[string]*keyState),
+	}
+}
+
+// UnregisterExecution removes tracking state for an execution.
+func (t *Tracker) UnregisterExecution(executionID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.execs, executionID)
+}
+
+// Process validates and resolves the at value for a metric entry.
+// Returns the resolved at value and whether the entry should be recorded.
+// If at is nil, auto-at (time since execution start) is used.
+func (t *Tracker) Process(executionID, key string, at *float64) (float64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	exec, ok := t.execs[executionID]
+	if !ok {
+		// Unknown execution — use current time as fallback
+		return float64(time.Now().UnixMilli()) / 1000.0, true
+	}
+
+	ks, exists := exec.keys[key]
+	if !exists {
+		ks = &keyState{mode: atModeUnknown}
+		exec.keys[key] = ks
+	}
+
+	var resolvedAt float64
+
+	if at == nil {
+		// Auto-at mode
+		if ks.mode == atModeCustom {
+			// Consistency violation: was custom, now auto
+			if !ks.warned {
+				t.logger.Warn("metric key switched from custom to auto at, using auto",
+					"execution_id", executionID, "key", key)
+				ks.warned = true
+			}
+		}
+		ks.mode = atModeAuto
+		resolvedAt = time.Since(exec.startTime).Seconds()
+	} else {
+		// Custom-at mode
+		if ks.mode == atModeAuto {
+			// Consistency violation: was auto, now custom
+			if !ks.warned {
+				t.logger.Warn("metric key switched from auto to custom at, using auto",
+					"execution_id", executionID, "key", key)
+				ks.warned = true
+			}
+			// Fall back to auto
+			ks.mode = atModeAuto
+			resolvedAt = time.Since(exec.startTime).Seconds()
+		} else {
+			ks.mode = atModeCustom
+			resolvedAt = *at
+
+			// Check monotonicity
+			if exists && resolvedAt <= ks.lastAt {
+				if !ks.warned {
+					t.logger.Warn(fmt.Sprintf("metric at value not increasing (%.4f <= %.4f), dropping",
+						resolvedAt, ks.lastAt),
+						"execution_id", executionID, "key", key)
+					ks.warned = true
+				}
+				return 0, false
+			}
+		}
+	}
+
+	ks.lastAt = resolvedAt
+	return resolvedAt, true
+}

--- a/cli/internal/pool/pool.go
+++ b/cli/internal/pool/pool.go
@@ -35,6 +35,10 @@ type ExecutionHandler interface {
 	// RecordLog records a log message (level: 0=debug, 1=stdout, 2=info, 3=stderr, 4=warning, 5=error)
 	// Template is the message template, values contains serialized values (each is ["raw", data, refs] or ["blob", key, size, refs])
 	RecordLog(ctx context.Context, executionID string, level int, template *string, values map[string]*adapter.Value) error
+	// DefineMetric defines a metric for an execution (metadata only)
+	DefineMetric(ctx context.Context, executionID string, key string, definition map[string]any) error
+	// RecordMetric records a metric data point
+	RecordMetric(ctx context.Context, executionID string, key string, value float64, at *float64) error
 	// ReportResult reports execution completion
 	ReportResult(ctx context.Context, executionID string, result *adapter.Value) error
 	// ReportError reports execution failure
@@ -217,6 +221,12 @@ loop:
 		case "log":
 			p.handleLog(ctx, executionID, params, logger)
 
+		case "define_metric":
+			p.handleDefineMetric(ctx, executionID, params, logger)
+
+		case "metric":
+			p.handleMetric(ctx, executionID, params, logger)
+
 		case "submit_execution", "resolve_reference", "persist_asset", "get_asset", "suspend", "cancel_execution", "download_blob", "upload_blob":
 			p.handleRequest(ctx, exec, method, *id, params, logger)
 
@@ -336,6 +346,39 @@ func (p *Pool) handleLog(ctx context.Context, executionID string, params json.Ra
 
 	if err := p.handler.RecordLog(ctx, logMsg.ExecutionID, logMsg.Level, logMsg.Template, logMsg.Values); err != nil {
 		logger.Error("failed to record log", "error", err)
+	}
+}
+
+func (p *Pool) handleDefineMetric(ctx context.Context, executionID string, params json.RawMessage, logger *slog.Logger) {
+	var msg struct {
+		ExecutionID string         `json:"execution_id"`
+		Key         string         `json:"key"`
+		Definition  map[string]any `json:"definition"`
+	}
+	if err := json.Unmarshal(params, &msg); err != nil {
+		logger.Error("failed to parse define_metric message", "error", err)
+		return
+	}
+
+	if err := p.handler.DefineMetric(ctx, msg.ExecutionID, msg.Key, msg.Definition); err != nil {
+		logger.Error("failed to define metric", "error", err)
+	}
+}
+
+func (p *Pool) handleMetric(ctx context.Context, executionID string, params json.RawMessage, logger *slog.Logger) {
+	var metricMsg struct {
+		ExecutionID string   `json:"execution_id"`
+		Key         string   `json:"key"`
+		Value       float64  `json:"value"`
+		At          *float64 `json:"at,omitempty"`
+	}
+	if err := json.Unmarshal(params, &metricMsg); err != nil {
+		logger.Error("failed to parse metric message", "error", err)
+		return
+	}
+
+	if err := p.handler.RecordMetric(ctx, metricMsg.ExecutionID, metricMsg.Key, metricMsg.Value, metricMsg.At); err != nil {
+		logger.Error("failed to record metric", "error", err)
 	}
 }
 

--- a/cli/internal/worker/worker.go
+++ b/cli/internal/worker/worker.go
@@ -205,11 +205,7 @@ func (w *Worker) Run(ctx context.Context, modules []string, register bool) error
 	}
 	metricStore := metric.NewHTTPStore(metricURL, metricToken, metricBatchSize, metricFlushInterval, w.logger)
 
-	throttleRate := w.cfg.Metrics.ThrottleRate
-	if throttleRate <= 0 {
-		throttleRate = 10 // default: 10 points per key per second
-	}
-	w.throttle = metric.NewThrottle(metricStore, throttleRate)
+	w.throttle = metric.NewThrottle(metricStore)
 	w.metrics = w.throttle
 	w.tracker = metric.NewTracker(w.logger)
 	defer func() { _ = w.metrics.Close() }()
@@ -1018,6 +1014,11 @@ func (w *Worker) RecordLog(ctx context.Context, executionID string, level int, t
 }
 
 func (w *Worker) DefineMetric(ctx context.Context, executionID string, key string, definition map[string]any) error {
+	if throttle, ok := definition["throttle"].(float64); ok {
+		w.throttle.SetRate(key, throttle)
+	} else {
+		w.throttle.DisableRate(key)
+	}
 	if conn := w.getConn(); conn != nil {
 		return conn.Notify("define_metric", executionID, key, definition)
 	}

--- a/cli/internal/worker/worker.go
+++ b/cli/internal/worker/worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bitroot/coflux/cli/internal/blob"
 	"github.com/bitroot/coflux/cli/internal/config"
 	logstore "github.com/bitroot/coflux/cli/internal/log"
+	"github.com/bitroot/coflux/cli/internal/metric"
 	"github.com/bitroot/coflux/cli/internal/pool"
 	"github.com/bitroot/coflux/cli/internal/version"
 	"github.com/gorilla/websocket"
@@ -46,6 +47,9 @@ type Worker struct {
 	pool        *pool.Pool
 	blobs       *blob.Manager
 	logs        logstore.Store
+	metrics     metric.Store
+	tracker     *metric.Tracker
+	throttle    *metric.Throttle
 
 	connMu sync.RWMutex
 	conn   *api.Connection
@@ -184,6 +188,31 @@ func (w *Worker) Run(ctx context.Context, modules []string, register bool) error
 	flushInterval := time.Duration(w.cfg.Logs.FlushInterval * float64(time.Second))
 	w.logs = logstore.NewHTTPStore(logURL, logToken, w.cfg.Logs.BatchSize, flushInterval, w.logger)
 	defer func() { _ = w.logs.Close() }()
+
+	// Setup metric store
+	metricURL := w.cfg.HTTPURL() + "/metrics"
+	metricToken := w.sessionID
+	if w.cfg.Metrics.Token != nil {
+		metricToken = *w.cfg.Metrics.Token
+	}
+	metricBatchSize := w.cfg.Metrics.BatchSize
+	if metricBatchSize <= 0 {
+		metricBatchSize = 100
+	}
+	metricFlushInterval := time.Duration(w.cfg.Metrics.FlushInterval * float64(time.Second))
+	if metricFlushInterval <= 0 {
+		metricFlushInterval = 500 * time.Millisecond
+	}
+	metricStore := metric.NewHTTPStore(metricURL, metricToken, metricBatchSize, metricFlushInterval, w.logger)
+
+	throttleRate := w.cfg.Metrics.ThrottleRate
+	if throttleRate <= 0 {
+		throttleRate = 10 // default: 10 points per key per second
+	}
+	w.throttle = metric.NewThrottle(metricStore, throttleRate)
+	w.metrics = w.throttle
+	w.tracker = metric.NewTracker(w.logger)
+	defer func() { _ = w.metrics.Close() }()
 
 	// Determine pool size (default to CPU count + 4)
 	poolSize := w.cfg.Worker.Concurrency
@@ -411,15 +440,25 @@ func (w *Worker) handleExecute(params []any) error {
 	w.logger.Debug("executing", "execution_id", executionID, "module", moduleName, "target", targetName, "run_id", runID)
 
 	// Track execution
+	startTime := time.Now()
+	targetKey := moduleName + "/" + targetName
 	w.mu.Lock()
 	w.executions[executionID] = &executionState{
 		status:      "starting",
-		startTime:   time.Now(),
-		target:      moduleName + "/" + targetName,
+		startTime:   startTime,
+		target:      targetKey,
 		runID:       runID,
 		workspaceID: workspaceID,
 	}
 	w.mu.Unlock()
+
+	// Register with metric tracker
+	w.tracker.RegisterExecution(executionID, startTime)
+
+	// Send "started" message
+	if conn := w.getConn(); conn != nil {
+		_ = conn.Notify("started", executionID, map[string]any{})
+	}
 
 	// Convert arguments to adapter format
 	args, err := w.convertArguments(arguments)
@@ -978,6 +1017,42 @@ func (w *Worker) RecordLog(ctx context.Context, executionID string, level int, t
 	return w.logs.Log(entry)
 }
 
+func (w *Worker) DefineMetric(ctx context.Context, executionID string, key string, definition map[string]any) error {
+	if conn := w.getConn(); conn != nil {
+		return conn.Notify("define_metric", executionID, key, definition)
+	}
+	return nil
+}
+
+func (w *Worker) RecordMetric(ctx context.Context, executionID string, key string, value float64, at *float64) error {
+	// Get execution context
+	w.mu.RLock()
+	state, ok := w.executions[executionID]
+	w.mu.RUnlock()
+
+	if !ok {
+		w.logger.Warn("metric for unknown execution", "execution_id", executionID)
+		return nil
+	}
+
+	// Process through tracker (validates at, computes auto-at)
+	resolvedAt, shouldRecord := w.tracker.Process(executionID, key, at)
+	if !shouldRecord {
+		return nil
+	}
+
+	entry := metric.Entry{
+		RunID:       state.runID,
+		ExecutionID: executionID,
+		WorkspaceID: state.workspaceID,
+		Key:         key,
+		Value:       value,
+		At:          resolvedAt,
+	}
+
+	return w.metrics.Record([]metric.Entry{entry})
+}
+
 // convertValueToLogFormat converts an adapter value to the log server format.
 // This is the log equivalent of convertValueToServerFormat — same input format
 // (adapter.Value) but outputs maps instead of tuples for the log HTTP API.
@@ -1336,6 +1411,10 @@ func (w *Worker) trySendTerminated(executionID string) {
 
 // NotifyTerminated is called by the pool after an execution's process has exited.
 func (w *Worker) NotifyTerminated(ctx context.Context, executionID string) error {
+	// Clean up metric tracking for this execution
+	w.tracker.UnregisterExecution(executionID)
+	w.throttle.RemoveExecution(executionID)
+
 	w.mu.Lock()
 	state, ok := w.executions[executionID]
 	if !ok {

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.10.0
 
-No changes.
+Enhancements:
+
+- Adds support for storing metrics and their definitions.
 
 ## 0.9.0
 

--- a/server/lib/coflux/application.ex
+++ b/server/lib/coflux/application.ex
@@ -1,7 +1,7 @@
 defmodule Coflux.Application do
   use Application
 
-  alias Coflux.{Config, JwksStore, Orchestration, Logs, Topics}
+  alias Coflux.{Config, JwksStore, Orchestration, Logs, Metrics, Topics}
 
   @impl true
   def start(_type, _args) do
@@ -16,6 +16,8 @@ defmodule Coflux.Application do
       Orchestration.Supervisor,
       {Registry, keys: :unique, name: Coflux.Logs.Registry},
       Logs.Supervisor,
+      {Registry, keys: :unique, name: Coflux.Metrics.Registry},
+      Metrics.Supervisor,
       {Topical, name: Coflux.TopicalRegistry, topics: topics()},
       {Coflux.Web, port: port},
       JwksStore

--- a/server/lib/coflux/handlers/metrics.ex
+++ b/server/lib/coflux/handlers/metrics.ex
@@ -1,0 +1,281 @@
+defmodule Coflux.Handlers.Metrics do
+  @moduledoc """
+  HTTP handler for the metrics endpoint.
+
+  - POST /metrics - Accept batched metric entries
+  - GET /metrics?run=X - Query metrics (JSON) or subscribe (SSE)
+
+  Project is resolved from the request (COFLUX_PROJECT env or subdomain).
+  SSE is enabled when Accept: text/event-stream header is present.
+  """
+
+  import Coflux.Handlers.Utils
+
+  alias Coflux.{Auth, Metrics}
+
+  def init(req, opts) do
+    req = set_cors_headers(req)
+
+    case :cowboy_req.method(req) do
+      "OPTIONS" ->
+        req = :cowboy_req.reply(204, req)
+        {:ok, req, opts}
+
+      "POST" ->
+        handle_post(req, opts)
+
+      "GET" ->
+        handle_get(req, opts)
+
+      _ ->
+        req = json_error_response(req, "method_not_allowed", status: 405)
+        {:ok, req, opts}
+    end
+  end
+
+  ## POST /metrics - Write metric entries
+
+  defp handle_post(req, opts) do
+    host = get_host(req)
+
+    with {:ok, project_id} <- resolve_project(host),
+         {:ok, _access} <- Auth.check(get_token(req), project_id, host) do
+      handle_post_with_project(req, opts, project_id)
+    else
+      {:error, :unauthorized} ->
+        req = json_error_response(req, "unauthorized", status: 401)
+        {:ok, req, opts}
+
+      {:error, :not_configured} ->
+        req = json_error_response(req, "not_configured", status: 500)
+        {:ok, req, opts}
+
+      {:error, :project_required} ->
+        req = json_error_response(req, "project_required", status: 400)
+        {:ok, req, opts}
+
+      {:error, :invalid_host} ->
+        req = json_error_response(req, "invalid_host", status: 400)
+        {:ok, req, opts}
+    end
+  end
+
+  defp handle_post_with_project(req, opts, project_id) do
+    case read_json_body(req) do
+      {:ok, body, req} ->
+        with {:ok, entries_data} <- get_required(body, "entries"),
+             {:ok, entries} <- parse_entries(entries_data) do
+          :ok = Metrics.Server.write_metrics(project_id, entries)
+          req = json_response(req, 200, %{"ok" => true})
+          {:ok, req, opts}
+        else
+          {:error, field, reason} ->
+            req =
+              json_error_response(req, "invalid_request",
+                details: %{"field" => field, "reason" => reason}
+              )
+
+            {:ok, req, opts}
+        end
+
+      {:error, :invalid_json} ->
+        req = json_error_response(req, "invalid_json")
+        {:ok, req, opts}
+    end
+  end
+
+  ## GET /metrics - Query or subscribe to metrics
+
+  defp handle_get(req, opts) do
+    host = get_host(req)
+
+    with {:ok, project_id} <- resolve_project(host),
+         {:ok, _access} <- Auth.check(get_token(req), project_id, host) do
+      handle_get_with_project(req, opts, project_id)
+    else
+      {:error, :unauthorized} ->
+        req = json_error_response(req, "unauthorized", status: 401)
+        {:ok, req, opts}
+
+      {:error, :not_configured} ->
+        req = json_error_response(req, "not_configured", status: 500)
+        {:ok, req, opts}
+
+      {:error, :project_required} ->
+        req = json_error_response(req, "project_required", status: 400)
+        {:ok, req, opts}
+
+      {:error, :invalid_host} ->
+        req = json_error_response(req, "invalid_host", status: 400)
+        {:ok, req, opts}
+    end
+  end
+
+  defp handle_get_with_project(req, opts, project_id) do
+    qs = :cowboy_req.parse_qs(req)
+    accept = :cowboy_req.header("accept", req, "application/json")
+
+    run_id = get_query_param(qs, "run")
+    execution_id = get_query_param(qs, "execution")
+    workspace_ids = parse_string_list(get_query_param(qs, "workspaces"))
+    keys = parse_string_list(get_query_param(qs, "keys"))
+    after_cursor = get_query_param(qs, "after")
+    from = parse_integer_param(get_query_param(qs, "from"))
+
+    cond do
+      is_nil(run_id) and is_nil(execution_id) ->
+        req = json_error_response(req, "run_or_execution_required")
+        {:ok, req, opts}
+
+      String.contains?(accept, "text/event-stream") and run_id != nil ->
+        handle_sse(req, opts, project_id, run_id, execution_id, workspace_ids, keys, from)
+
+      true ->
+        query_opts =
+          []
+          |> then(fn o -> if run_id, do: [{:run_id, run_id} | o], else: o end)
+          |> then(fn o -> if execution_id, do: [{:execution_id, execution_id} | o], else: o end)
+          |> then(fn o ->
+            if workspace_ids != [], do: [{:workspace_ids, workspace_ids} | o], else: o
+          end)
+          |> then(fn o -> if keys != [], do: [{:keys, keys} | o], else: o end)
+          |> then(fn o -> if after_cursor, do: [{:after, after_cursor} | o], else: o end)
+          |> then(fn o -> if from, do: [{:from, from} | o], else: o end)
+
+        case Metrics.Server.query_metrics(project_id, query_opts) do
+          {:ok, entries, cursor} ->
+            result = %{
+              "metrics" => Enum.map(entries, &format_entry/1),
+              "cursor" => cursor
+            }
+
+            req = json_response(req, 200, result)
+            {:ok, req, opts}
+
+          {:error, reason} ->
+            req =
+              json_error_response(req, "query_failed", details: %{"reason" => inspect(reason)})
+
+            {:ok, req, opts}
+        end
+    end
+  end
+
+  ## SSE Handling
+
+  defp handle_sse(req, opts, project_id, run_id, execution_id, workspace_ids, keys, from) do
+    subscribe_opts =
+      []
+      |> then(fn o -> if execution_id, do: [{:execution_id, execution_id} | o], else: o end)
+      |> then(fn o ->
+        if workspace_ids != [], do: [{:workspace_ids, workspace_ids} | o], else: o
+      end)
+      |> then(fn o -> if keys != [], do: [{:keys, keys} | o], else: o end)
+      |> then(fn o -> if from, do: [{:from, from} | o], else: o end)
+
+    case Metrics.Server.subscribe(project_id, run_id, self(), subscribe_opts) do
+      {:ok, ref, initial_entries} ->
+        headers = %{
+          "content-type" => "text/event-stream",
+          "cache-control" => "no-cache",
+          "connection" => "keep-alive"
+        }
+
+        req = :cowboy_req.stream_reply(200, headers, req)
+        send_sse_data(req, Enum.map(initial_entries, &format_entry/1))
+        {:cowboy_loop, req, %{ref: ref, project_id: project_id}}
+
+      {:error, _reason} ->
+        req = json_error_response(req, "subscription_failed", status: 500)
+        {:ok, req, opts}
+    end
+  end
+
+  def info({:metrics, ref, entries}, req, %{ref: ref} = state) do
+    if Enum.any?(entries) do
+      send_sse_data(req, Enum.map(entries, &format_entry/1))
+    end
+
+    {:ok, req, state}
+  end
+
+  def info(_msg, req, state) do
+    {:ok, req, state}
+  end
+
+  def terminate(_reason, _req, %{ref: ref, project_id: project_id}) do
+    Metrics.Server.unsubscribe(project_id, ref)
+    :ok
+  end
+
+  def terminate(_reason, _req, _state) do
+    :ok
+  end
+
+  ## Helpers
+
+  defp get_required(body, field) do
+    case Map.fetch(body, field) do
+      {:ok, value} when not is_nil(value) -> {:ok, value}
+      _ -> {:error, field, "required"}
+    end
+  end
+
+  defp parse_entries(entries) when is_list(entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      parsed = %{
+        run_id: Map.get(entry, "runId"),
+        execution_id: Map.get(entry, "executionId"),
+        workspace_id: Map.get(entry, "workspaceId"),
+        key: Map.get(entry, "key"),
+        value: Map.get(entry, "value"),
+        at: Map.get(entry, "at")
+      }
+
+      if is_binary(parsed.run_id) and is_binary(parsed.execution_id) and
+           is_binary(parsed.workspace_id) and is_binary(parsed.key) and
+           is_number(parsed.value) and is_number(parsed.at) do
+        {:cont, {:ok, [parsed | acc]}}
+      else
+        {:halt, {:error, "entries", "invalid entry structure"}}
+      end
+    end)
+    |> case do
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
+      error -> error
+    end
+  end
+
+  defp parse_entries(_), do: {:error, "entries", "must be an array"}
+
+  defp parse_string_list(nil), do: []
+  defp parse_string_list(""), do: []
+
+  defp parse_string_list(value) when is_binary(value) do
+    String.split(value, ",")
+  end
+
+  defp parse_integer_param(nil), do: nil
+
+  defp parse_integer_param(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> nil
+    end
+  end
+
+  defp format_entry(entry) do
+    %{
+      "executionId" => entry.execution_id,
+      "workspaceId" => entry.workspace_id,
+      "key" => entry.key,
+      "value" => entry.value,
+      "at" => entry.at
+    }
+  end
+
+  defp send_sse_data(req, metrics) do
+    message = "data: #{Jason.encode!(metrics)}\n\n"
+    :cowboy_req.stream_body(message, :nofin, req)
+  end
+end

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -169,6 +169,35 @@ defmodule Coflux.Handlers.Worker do
           {[{:close, 4000, "execution_invalid"}], nil}
         end
 
+      "started" ->
+        [execution_id, metadata] = message["params"]
+
+        if is_recognised_execution?(execution_id, state) do
+          :ok =
+            Orchestration.execution_started(
+              state.project_id,
+              execution_id,
+              metadata
+            )
+        end
+
+        {[], state}
+
+      "define_metric" ->
+        [execution_id, key, definition] = message["params"]
+
+        if is_recognised_execution?(execution_id, state) do
+          :ok =
+            Orchestration.define_metric(
+              state.project_id,
+              execution_id,
+              key,
+              definition
+            )
+        end
+
+        {[], state}
+
       "record_heartbeats" ->
         [executions] = message["params"]
 

--- a/server/lib/coflux/metrics/server.ex
+++ b/server/lib/coflux/metrics/server.ex
@@ -1,0 +1,623 @@
+defmodule Coflux.Metrics.Server do
+  @moduledoc """
+  Per-project GenServer for metric storage with write buffering and partitioned storage.
+
+  Features:
+  - Buffers writes in memory for batch inserts
+  - Flushes on interval or when buffer is full
+  - Partitioned SQLite epoch files with size-based rotation
+  - Bloom filter index for efficient cross-partition lookups
+  - Pub/sub for real-time metric streaming
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Coflux.Metrics.Store
+  alias Coflux.Store.{Bloom, Epochs, Index}
+  alias Exqlite.Sqlite3
+
+  @flush_interval_ms 200
+  @max_buffer_size 1000
+  @rotation_size_threshold_bytes 100 * 1024 * 1024
+
+  defmodule State do
+    @moduledoc false
+    defstruct [
+      :project_id,
+      :epochs,
+      :metric_index,
+      :flush_timer,
+      :index_task,
+      index_queue: [],
+      buffer: [],
+      # run_id -> %{ref -> {pid, execution_id, workspace_ids, keys}}
+      subscribers: %{}
+    ]
+  end
+
+  ## Client API
+
+  def start_link(opts) do
+    project_id = Keyword.fetch!(opts, :project_id)
+
+    GenServer.start_link(__MODULE__, project_id,
+      name: {:via, Registry, {Coflux.Metrics.Registry, project_id}}
+    )
+  end
+
+  @doc """
+  Write a batch of metric entries.
+
+  Each entry should be a map with:
+  - run_id: string
+  - execution_id: string
+  - workspace_id: string
+  - key: string
+  - value: float
+  - at: float
+  """
+  def write_metrics(project_id, entries) when is_list(entries) do
+    {:ok, server} = Coflux.Metrics.Supervisor.get_server(project_id)
+    GenServer.cast(server, {:write_metrics, entries})
+  end
+
+  @doc """
+  Query metrics.
+
+  Options:
+  - :run_id - filter by run
+  - :execution_id - filter by execution
+  - :workspace_ids - list of workspace IDs to include
+  - :keys - list of metric key names
+  - :after - cursor for pagination
+  - :from - unix ms timestamp to skip partitions created before this time
+  - :limit - max results
+  """
+  def query_metrics(project_id, opts) do
+    {:ok, server} = Coflux.Metrics.Supervisor.get_server(project_id)
+    GenServer.call(server, {:query_metrics, opts})
+  end
+
+  @doc """
+  Subscribe to real-time metric updates for a run.
+
+  Options:
+  - :execution_id - filter to only metrics from this execution
+  - :workspace_ids - list of workspace IDs to include
+  - :keys - list of metric key names to include
+  - :from - unix ms timestamp to skip old partitions in initial snapshot
+
+  Returns {:ok, ref, initial_metrics} where ref is used to unsubscribe.
+  The subscriber will receive {:metrics, ref, entries} messages.
+  """
+  def subscribe(project_id, run_id, pid, opts \\ []) do
+    {:ok, server} = Coflux.Metrics.Supervisor.get_server(project_id)
+    GenServer.call(server, {:subscribe, run_id, pid, opts})
+  end
+
+  @doc """
+  Unsubscribe from metric updates.
+  """
+  def unsubscribe(project_id, ref) do
+    case Coflux.Metrics.Supervisor.get_server(project_id) do
+      {:ok, server} -> GenServer.cast(server, {:unsubscribe, ref})
+      _ -> :ok
+    end
+  end
+
+  @doc """
+  Force a partition rotation regardless of size.
+  """
+  def rotate(project_id) do
+    {:ok, server} = Coflux.Metrics.Supervisor.get_server(project_id)
+    GenServer.call(server, :rotate)
+  end
+
+  ## Server Callbacks
+
+  @impl true
+  def init(project_id) do
+    index_path = ["projects", project_id, "metrics", "index.json"]
+    {:ok, metric_index} = Index.load(index_path, ["runs"])
+    unindexed_epoch_ids = Index.unindexed_epoch_ids(metric_index)
+    archived_epoch_ids = Index.all_epoch_ids(metric_index)
+
+    case Epochs.open(project_id, "metrics",
+           unindexed_epoch_ids: unindexed_epoch_ids,
+           archived_epoch_ids: archived_epoch_ids
+         ) do
+      {:ok, epochs} ->
+        state = %State{
+          project_id: project_id,
+          epochs: epochs,
+          metric_index: metric_index,
+          index_queue: unindexed_epoch_ids
+        }
+
+        state = maybe_start_index_build(state)
+        {:ok, state}
+    end
+  end
+
+  @impl true
+  def handle_cast({:write_metrics, entries}, state) do
+    state = %{state | buffer: state.buffer ++ entries}
+    state = maybe_flush(state)
+    state = schedule_flush(state)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:unsubscribe, ref}, state) do
+    state = do_unsubscribe(state, ref)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call({:query_metrics, opts}, _from, state) do
+    # Flush buffer first to include recent writes
+    state = flush_buffer(state)
+    result = query_cross_partition(state, opts)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:subscribe, run_id, pid, opts}, _from, state) do
+    ref = make_ref()
+    execution_id = Keyword.get(opts, :execution_id)
+    workspace_ids = Keyword.get(opts, :workspace_ids)
+    keys = Keyword.get(opts, :keys)
+    from = Keyword.get(opts, :from)
+
+    # Monitor the subscriber
+    Process.monitor(pid)
+
+    # Flush buffer first
+    state = flush_buffer(state)
+
+    query_opts =
+      [run_id: run_id]
+      |> then(fn o -> if execution_id, do: [{:execution_id, execution_id} | o], else: o end)
+      |> then(fn o ->
+        if workspace_ids && workspace_ids != [],
+          do: [{:workspace_ids, workspace_ids} | o],
+          else: o
+      end)
+      |> then(fn o -> if keys && keys != [], do: [{:keys, keys} | o], else: o end)
+      |> then(fn o -> if from, do: [{:from, from} | o], else: o end)
+
+    {:ok, initial_metrics, _cursor} =
+      query_cross_partition(state, Keyword.put(query_opts, :limit, 1_000_000))
+
+    # Add to subscribers with optional filters
+    state =
+      state
+      |> update_in(
+        [Access.key(:subscribers), Access.key(run_id, %{})],
+        &Map.put(&1, ref, {pid, execution_id, workspace_ids, keys})
+      )
+
+    {:reply, {:ok, ref, initial_metrics}, state}
+  end
+
+  @impl true
+  def handle_call(:rotate, _from, state) do
+    state = flush_buffer(state)
+    state = do_rotate(state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:flush, state) do
+    state = flush_buffer(state)
+    {:noreply, %{state | flush_timer: nil}}
+  end
+
+  @impl true
+  def handle_info({task_ref, run_bloom}, state)
+      when task_ref == state.index_task do
+    Process.demonitor(task_ref, [:flush])
+    [epoch_id | rest] = state.index_queue
+
+    metric_index = Index.update_filters(state.metric_index, epoch_id, %{"runs" => run_bloom})
+    :ok = Index.save(metric_index)
+    epochs = Epochs.promote_to_indexed(state.epochs, epoch_id)
+
+    state =
+      %{state | metric_index: metric_index, epochs: epochs, index_task: nil, index_queue: rest}
+
+    {:noreply, maybe_start_index_build(state)}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    cond do
+      ref == state.index_task ->
+        [failed | rest] = state.index_queue
+
+        Logger.warning(
+          "metric index build failed for epoch #{failed} in project #{state.project_id}"
+        )
+
+        state = %{state | index_task: nil, index_queue: rest}
+        state = maybe_start_index_build(state)
+        {:noreply, state}
+
+      true ->
+        # Subscriber process died
+        state = remove_subscriber_by_pid(state, pid)
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    if state.epochs do
+      Epochs.close(state.epochs)
+    end
+
+    :ok
+  end
+
+  ## Private Functions — Flush & Rotation
+
+  defp flush_buffer(%{buffer: []} = state), do: state
+
+  defp flush_buffer(state) do
+    db = Epochs.active_db(state.epochs)
+
+    case Store.insert_metrics(db, state.buffer) do
+      :ok ->
+        notify_subscribers(state, state.buffer)
+
+        %{state | buffer: []}
+        |> maybe_rotate()
+
+      {:error, reason} ->
+        Logger.warning("Failed to flush metrics: #{inspect(reason)}")
+        %{state | buffer: []}
+    end
+  end
+
+  defp maybe_flush(state) when length(state.buffer) >= @max_buffer_size do
+    flush_buffer(state)
+  end
+
+  defp maybe_flush(state), do: state
+
+  defp schedule_flush(%{flush_timer: nil} = state) do
+    timer = Process.send_after(self(), :flush, @flush_interval_ms)
+    %{state | flush_timer: timer}
+  end
+
+  defp schedule_flush(state), do: state
+
+  defp maybe_rotate(state) do
+    if Epochs.active_db_size(state.epochs) >= @rotation_size_threshold_bytes do
+      do_rotate(state)
+    else
+      state
+    end
+  end
+
+  defp do_rotate(state) do
+    epoch_id = Epochs.next_epoch_id(state.epochs)
+
+    # Write placeholder entry to index first (null value)
+    metric_index = Index.add_epoch(state.metric_index, epoch_id, System.os_time(:millisecond))
+    :ok = Index.save(metric_index)
+
+    # Now rotate
+    {:ok, new_epochs, _old_db} = Epochs.rotate(state.epochs, epoch_id)
+
+    %{
+      state
+      | epochs: new_epochs,
+        metric_index: metric_index,
+        index_queue: state.index_queue ++ [epoch_id]
+    }
+    |> maybe_start_index_build()
+  end
+
+  ## Private Functions — Bloom Filter Building
+
+  defp maybe_start_index_build(%{index_task: nil, index_queue: [epoch_id | _]} = state) do
+    path = Epochs.archive_path(state.epochs, epoch_id)
+
+    task =
+      Task.Supervisor.async_nolink(Coflux.LauncherSupervisor, fn ->
+        {:ok, db} = Sqlite3.open(path)
+
+        try do
+          build_bloom_for_partition(db)
+        after
+          Sqlite3.close(db)
+        end
+      end)
+
+    %{state | index_task: task.ref}
+  end
+
+  defp maybe_start_index_build(state), do: state
+
+  defp build_bloom_for_partition(db) do
+    import Coflux.Store
+
+    {:ok, [{count}]} = query(db, "SELECT COUNT(DISTINCT run_id) FROM metrics")
+    bloom = Bloom.new(max(100, count))
+
+    {:ok, run_ids} = query(db, "SELECT DISTINCT run_id FROM metrics")
+
+    Enum.reduce(run_ids, bloom, fn {id}, b -> Bloom.add(b, id) end)
+  end
+
+  defp archived_before?(_epoch_id, nil), do: false
+
+  defp archived_before?(epoch_id, from_ms) do
+    case epoch_id_date(epoch_id) do
+      nil ->
+        false
+
+      date ->
+        from_date = from_ms |> DateTime.from_unix!(:millisecond) |> DateTime.to_date()
+        Date.compare(date, from_date) == :lt
+    end
+  end
+
+  defp epoch_id_date(epoch_id) do
+    case String.split(epoch_id, "_") do
+      [date_str, _counter] ->
+        case Date.from_iso8601(date_str, :basic) do
+          {:ok, date} -> date
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  ## Private Functions — Cross-Partition Query
+
+  defp query_cross_partition(state, opts) do
+    run_id = Keyword.get(opts, :run_id)
+    _execution_id = Keyword.get(opts, :execution_id)
+    from = Keyword.get(opts, :from)
+    after_cursor = Keyword.get(opts, :after)
+    limit = Keyword.get(opts, :limit, 1000)
+
+    # For execution queries, we still need run_id for bloom filter lookups.
+    # If only execution_id is given, skip bloom filtering and scan all partitions.
+    use_bloom? = run_id != nil
+
+    {cursor_epoch_id, cursor_at, cursor_id} = parse_cross_cursor(after_cursor)
+    skip_archives? = cursor_epoch_id == :active
+
+    archived_candidates =
+      if skip_archives? do
+        []
+      else
+        candidates =
+          if use_bloom? do
+            state.metric_index
+            |> Index.find_epochs("runs", run_id)
+            |> Enum.reject(&archived_before?(&1, from))
+            |> Enum.sort()
+          else
+            # No run_id — scan all archived partitions
+            state.metric_index
+            |> Index.all_epoch_ids()
+            |> Enum.reject(&archived_before?(&1, from))
+            |> Enum.sort()
+          end
+
+        if cursor_epoch_id do
+          Enum.drop_while(candidates, &(&1 != cursor_epoch_id))
+        else
+          candidates
+        end
+      end
+
+    unindexed_map = Map.new(state.epochs.unindexed)
+
+    {entries, remaining} =
+      Enum.reduce_while(archived_candidates, {[], limit}, fn epoch_id, {acc, remaining} ->
+        if remaining <= 0 do
+          {:halt, {acc, 0}}
+        else
+          partition_opts =
+            opts
+            |> Keyword.put(:limit, remaining)
+            |> Keyword.delete(:from)
+            |> maybe_apply_cursor(epoch_id == cursor_epoch_id, cursor_at, cursor_id)
+
+          {db, close_after?} = get_archived_db(state, epoch_id, unindexed_map)
+
+          result =
+            try do
+              Store.query_metrics(db, partition_opts)
+            after
+              if close_after?, do: Sqlite3.close(db)
+            end
+
+          {:ok, partition_entries, _cursor} = result
+
+          tagged =
+            Enum.map(partition_entries, &Map.put(&1, :_epoch_id, epoch_id))
+
+          {:cont, {acc ++ tagged, remaining - length(partition_entries)}}
+        end
+      end)
+
+    {entries, _remaining} =
+      if remaining > 0 do
+        active_opts =
+          opts
+          |> Keyword.put(:limit, remaining)
+          |> Keyword.delete(:from)
+          |> maybe_apply_cursor(skip_archives?, cursor_at, cursor_id)
+
+        db = Epochs.active_db(state.epochs)
+        {:ok, active_entries, _cursor} = Store.query_metrics(db, active_opts)
+        tagged = Enum.map(active_entries, &Map.put(&1, :_epoch_id, :active))
+        {entries ++ tagged, remaining - length(active_entries)}
+      else
+        {entries, remaining}
+      end
+
+    cursor = build_cross_cursor(List.last(entries))
+    entries = Enum.map(entries, &Map.delete(&1, :_epoch_id))
+
+    {:ok, entries, cursor}
+  end
+
+  defp parse_cross_cursor(nil), do: {nil, nil, nil}
+
+  defp parse_cross_cursor(cursor) when is_binary(cursor) do
+    case String.split(cursor, ":") do
+      [epoch_id, at_str, id_str] ->
+        case {Float.parse(at_str), Integer.parse(id_str)} do
+          {{at, ""}, {id, ""}} ->
+            partition = if epoch_id == "", do: :active, else: epoch_id
+            {partition, at, id}
+
+          _ ->
+            {nil, nil, nil}
+        end
+
+      [at_str, id_str] ->
+        case {Float.parse(at_str), Integer.parse(id_str)} do
+          {{at, ""}, {id, ""}} -> {:active, at, id}
+          _ -> {nil, nil, nil}
+        end
+
+      _ ->
+        {nil, nil, nil}
+    end
+  end
+
+  defp maybe_apply_cursor(opts, true, at, id) when not is_nil(at) do
+    Keyword.put(opts, :after, "#{at}:#{id}")
+  end
+
+  defp maybe_apply_cursor(opts, _, _, _) do
+    Keyword.delete(opts, :after)
+  end
+
+  defp get_archived_db(state, epoch_id, unindexed_map) do
+    case Map.fetch(unindexed_map, epoch_id) do
+      {:ok, db} ->
+        {db, false}
+
+      :error ->
+        path = Epochs.archive_path(state.epochs, epoch_id)
+        {:ok, db} = Sqlite3.open(path)
+        {db, true}
+    end
+  end
+
+  defp build_cross_cursor(nil), do: nil
+
+  defp build_cross_cursor(entry) do
+    epoch_prefix = if entry._epoch_id == :active, do: "", else: entry._epoch_id
+    "#{epoch_prefix}:#{entry.at}:#{entry.id}"
+  end
+
+  ## Private Functions — Subscribers
+
+  defp notify_subscribers(state, entries) do
+    entries_by_run = Enum.group_by(entries, & &1.run_id)
+
+    Enum.each(entries_by_run, fn {run_id, run_entries} ->
+      case Map.get(state.subscribers, run_id) do
+        nil ->
+          :ok
+
+        subs ->
+          Enum.each(subs, fn {ref, {pid, filter_execution_id, filter_workspace_ids, filter_keys}} ->
+            filtered_entries =
+              run_entries
+              |> maybe_filter_by_execution_id(filter_execution_id)
+              |> maybe_filter_by_workspace_ids(filter_workspace_ids)
+              |> maybe_filter_by_keys(filter_keys)
+
+            if Enum.any?(filtered_entries) do
+              formatted_entries = Enum.map(filtered_entries, &format_entry_for_notification/1)
+              send(pid, {:metrics, ref, formatted_entries})
+            end
+          end)
+      end
+    end)
+  end
+
+  defp maybe_filter_by_execution_id(entries, nil), do: entries
+
+  defp maybe_filter_by_execution_id(entries, execution_id) do
+    Enum.filter(entries, &(&1.execution_id == execution_id))
+  end
+
+  defp maybe_filter_by_workspace_ids(entries, nil), do: entries
+  defp maybe_filter_by_workspace_ids(entries, []), do: entries
+
+  defp maybe_filter_by_workspace_ids(entries, workspace_ids) do
+    Enum.filter(entries, &(&1.workspace_id in workspace_ids))
+  end
+
+  defp maybe_filter_by_keys(entries, nil), do: entries
+  defp maybe_filter_by_keys(entries, []), do: entries
+
+  defp maybe_filter_by_keys(entries, keys) do
+    Enum.filter(entries, &(&1.key in keys))
+  end
+
+  defp format_entry_for_notification(entry) do
+    Map.take(entry, [:execution_id, :workspace_id, :key, :value, :at])
+  end
+
+  defp do_unsubscribe(state, ref) do
+    {state, _} =
+      Enum.reduce(state.subscribers, {state, false}, fn
+        {run_id, subs}, {state, false} ->
+          if Map.has_key?(subs, ref) do
+            new_subs = Map.delete(subs, ref)
+
+            state =
+              if map_size(new_subs) == 0 do
+                update_in(state, [:subscribers], &Map.delete(&1, run_id))
+              else
+                put_in(state, [:subscribers, run_id], new_subs)
+              end
+
+            {state, true}
+          else
+            {state, false}
+          end
+
+        _, acc ->
+          acc
+      end)
+
+    state
+  end
+
+  defp remove_subscriber_by_pid(state, pid) do
+    new_subscribers =
+      state.subscribers
+      |> Enum.map(fn {run_id, subs} ->
+        new_subs =
+          subs
+          |> Enum.reject(fn {_ref, {sub_pid, _execution_id, _workspace_ids, _keys}} ->
+            sub_pid == pid
+          end)
+          |> Map.new()
+
+        {run_id, new_subs}
+      end)
+      |> Enum.reject(fn {_run_id, subs} -> map_size(subs) == 0 end)
+      |> Map.new()
+
+    %{state | subscribers: new_subscribers}
+  end
+end

--- a/server/lib/coflux/metrics/store.ex
+++ b/server/lib/coflux/metrics/store.ex
@@ -1,0 +1,176 @@
+defmodule Coflux.Metrics.Store do
+  @moduledoc """
+  SQLite database operations for metrics storage.
+
+  Provides functions for batch insert of metric entries and querying
+  metrics with filters.
+  """
+
+  alias Coflux.Store
+
+  @doc """
+  Insert a batch of metric entries.
+
+  Each entry should be a map with:
+  - run_id: string
+  - execution_id: string
+  - workspace_id: string
+  - key: string
+  - value: float
+  - at: float
+  """
+  def insert_metrics(db, entries) when is_list(entries) do
+    now = System.system_time(:millisecond)
+
+    rows =
+      Enum.map(entries, fn entry ->
+        {
+          entry.run_id,
+          entry.execution_id,
+          entry.workspace_id,
+          entry.key,
+          entry.value,
+          entry.at,
+          now
+        }
+      end)
+
+    fields = {:run_id, :execution_id, :workspace_id, :key, :value, :at, :created_at}
+
+    case Store.insert_many(db, "metrics", fields, rows) do
+      {:ok, _ids} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Query metrics with optional filters.
+
+  Options:
+  - :run_id - filter by run ID (required unless :execution_id is given)
+  - :execution_id - filter by execution ID
+  - :workspace_ids - list of workspace IDs to include
+  - :keys - list of metric key names to include
+  - :after - cursor for pagination (at:id format)
+  - :limit - max entries to return (default 1000)
+  """
+  def query_metrics(db, opts) do
+    run_id = Keyword.get(opts, :run_id)
+    execution_id = Keyword.get(opts, :execution_id)
+    workspace_ids = Keyword.get(opts, :workspace_ids)
+    keys = Keyword.get(opts, :keys)
+    after_cursor = Keyword.get(opts, :after)
+    limit = Keyword.get(opts, :limit, 1000)
+
+    {where_clauses, args} =
+      build_where_clauses(run_id, execution_id, workspace_ids, keys, after_cursor)
+
+    sql = """
+    SELECT m.id, m.run_id, m.execution_id, m.workspace_id, m.key, m.value, m.at, m.created_at
+    FROM metrics m
+    WHERE #{Enum.join(where_clauses, " AND ")}
+    ORDER BY m.at ASC, m.id ASC
+    LIMIT ?#{length(args) + 1}
+    """
+
+    args = List.to_tuple(args ++ [limit])
+
+    case Store.query(db, sql, args) do
+      {:ok, rows} ->
+        entries = Enum.map(rows, &row_to_entry/1)
+        cursor = build_cursor(List.last(entries))
+        {:ok, entries, cursor}
+    end
+  end
+
+  defp build_where_clauses(run_id, execution_id, workspace_ids, keys, after_cursor) do
+    {clauses, args} =
+      cond do
+        execution_id ->
+          {["m.execution_id = ?1"], [execution_id]}
+
+        run_id ->
+          {["m.run_id = ?1"], [run_id]}
+
+        true ->
+          {["1 = 0"], []}
+      end
+
+    {clauses, args} =
+      if workspace_ids && workspace_ids != [] do
+        start_idx = length(args) + 1
+
+        placeholders =
+          workspace_ids |> Enum.with_index(start_idx) |> Enum.map(fn {_, i} -> "?#{i}" end)
+
+        clause = "m.workspace_id IN (#{Enum.join(placeholders, ", ")})"
+        {clauses ++ [clause], args ++ workspace_ids}
+      else
+        {clauses, args}
+      end
+
+    {clauses, args} =
+      if keys && keys != [] do
+        start_idx = length(args) + 1
+
+        placeholders =
+          keys |> Enum.with_index(start_idx) |> Enum.map(fn {_, i} -> "?#{i}" end)
+
+        clause = "m.key IN (#{Enum.join(placeholders, ", ")})"
+        {clauses ++ [clause], args ++ keys}
+      else
+        {clauses, args}
+      end
+
+    {clauses, args} =
+      if after_cursor do
+        case parse_cursor(after_cursor) do
+          {:ok, at, id} ->
+            clause =
+              "(m.at > ?#{length(args) + 1} OR (m.at = ?#{length(args) + 1} AND m.id > ?#{length(args) + 2}))"
+
+            {clauses ++ [clause], args ++ [at, id]}
+
+          :error ->
+            {clauses, args}
+        end
+      else
+        {clauses, args}
+      end
+
+    {clauses, args}
+  end
+
+  defp parse_cursor(cursor) when is_binary(cursor) do
+    case String.split(cursor, ":") do
+      [at_str, id_str] ->
+        case {Float.parse(at_str), Integer.parse(id_str)} do
+          {{at, ""}, {id, ""}} -> {:ok, at, id}
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_cursor(_), do: :error
+
+  defp build_cursor(nil), do: nil
+
+  defp build_cursor(entry) do
+    "#{entry.at}:#{entry.id}"
+  end
+
+  defp row_to_entry({id, run_id, execution_id, workspace_id, key, value, at, _created_at}) do
+    %{
+      id: id,
+      run_id: run_id,
+      execution_id: execution_id,
+      workspace_id: workspace_id,
+      key: key,
+      value: value,
+      at: at
+    }
+  end
+end

--- a/server/lib/coflux/metrics/supervisor.ex
+++ b/server/lib/coflux/metrics/supervisor.ex
@@ -1,0 +1,48 @@
+defmodule Coflux.Metrics.Supervisor do
+  @moduledoc """
+  DynamicSupervisor for per-project metric servers.
+
+  Manages a pool of Metrics.Server processes, one per active project.
+  Servers are started on-demand when metrics are written or subscribed to.
+  """
+
+  use DynamicSupervisor
+
+  alias Coflux.Metrics.Server
+
+  def start_link(opts) do
+    DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @doc """
+  Get or start a metrics server for the given project.
+
+  Returns {:ok, pid} if successful.
+  """
+  def get_server(project_id) do
+    case Registry.lookup(Coflux.Metrics.Registry, project_id) do
+      [{pid, _}] ->
+        {:ok, pid}
+
+      [] ->
+        start_server(project_id)
+    end
+  end
+
+  defp start_server(project_id) do
+    spec = {Server, project_id: project_id}
+
+    case DynamicSupervisor.start_child(__MODULE__, spec) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, pid}} ->
+        {:ok, pid}
+    end
+  end
+end

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -137,6 +137,14 @@ defmodule Coflux.Orchestration do
     )
   end
 
+  def execution_started(project_id, execution_id, metadata) do
+    call_server(project_id, {:execution_started, execution_id, metadata})
+  end
+
+  def define_metric(project_id, execution_id, key, definition) do
+    call_server(project_id, {:define_metric, execution_id, key, definition})
+  end
+
   def record_heartbeats(project_id, executions, session_id) do
     call_server(project_id, {:record_heartbeats, executions, session_id})
   end

--- a/server/lib/coflux/orchestration/runs.ex
+++ b/server/lib/coflux/orchestration/runs.ex
@@ -85,6 +85,56 @@ defmodule Coflux.Orchestration.Runs do
     end
   end
 
+  def define_metric(db, execution_id, key, opts \\ %{}) do
+    now = current_timestamp()
+
+    insert_one(
+      db,
+      :metrics,
+      %{
+        execution_id: execution_id,
+        key: key,
+        group: Map.get(opts, "group"),
+        group_units: Map.get(opts, "group_units"),
+        group_lower: Map.get(opts, "group_lower"),
+        group_upper: Map.get(opts, "group_upper"),
+        scale: Map.get(opts, "scale"),
+        units: Map.get(opts, "units"),
+        progress: if(Map.get(opts, "progress", false), do: 1, else: 0),
+        lower: Map.get(opts, "lower"),
+        upper: Map.get(opts, "upper"),
+        created_at: now
+      },
+      on_conflict: "DO NOTHING"
+    )
+  end
+
+  def get_metric_definitions(db, execution_id) do
+    query(
+      db,
+      """
+      SELECT key, "group", group_units, group_lower, group_upper, scale, units, progress, lower, upper
+      FROM metrics
+      WHERE execution_id = ?1
+      """,
+      {execution_id}
+    )
+  end
+
+  def get_run_metric_definitions(db, run_id) do
+    query(
+      db,
+      """
+      SELECT e.id, m.key, m."group", m.group_units, m.group_lower, m.group_upper, m.scale, m.units, m.progress, m.lower, m.upper
+      FROM metrics AS m
+      INNER JOIN executions AS e ON e.id = m.execution_id
+      INNER JOIN steps AS s ON s.id = e.step_id
+      WHERE s.run_id = ?1
+      """,
+      {run_id}
+    )
+  end
+
   def get_workspace_id_for_execution(db, execution_id) do
     case query_one(
            db,

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -3731,8 +3731,20 @@ defmodule Coflux.Orchestration.Server do
       Enum.group_by(
         run_metric_defs,
         fn {execution_id, _, _, _, _, _, _, _, _, _, _} -> execution_id end,
-        fn {_, key, group, group_units, group_lower, group_upper, scale, units, progress, lower, upper} ->
-          {key, %{group: group, group_units: group_units, group_lower: group_lower, group_upper: group_upper, scale: scale, units: units, progress: progress == 1, lower: lower, upper: upper}}
+        fn {_, key, group, group_units, group_lower, group_upper, scale, units, progress, lower,
+            upper} ->
+          {key,
+           %{
+             group: group,
+             group_units: group_units,
+             group_lower: group_lower,
+             group_upper: group_upper,
+             scale: scale,
+             units: units,
+             progress: progress == 1,
+             lower: lower,
+             upper: upper
+           }}
         end
       )
       |> Map.new(fn {execution_id, defs} -> {execution_id, Map.new(defs)} end)

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1292,6 +1292,42 @@ defmodule Coflux.Orchestration.Server do
     end
   end
 
+  def handle_call({:execution_started, _external_execution_id, _metadata}, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:define_metric, external_execution_id, key, definition}, _from, state) do
+    state =
+      case Map.fetch(state.execution_ids, external_execution_id) do
+        {:ok, execution_id} ->
+          {:ok, _} = Runs.define_metric(state.db, execution_id, key, definition)
+
+          # Notify the run topic
+          case Runs.get_execution_run_id(state.db, execution_id) do
+            {:ok, run_id} ->
+              case Runs.get_run_by_id(state.db, run_id) do
+                {:ok, run} ->
+                  notify_listeners(
+                    state,
+                    {:run, run.external_id},
+                    {:metric_defined, external_execution_id, key, definition}
+                  )
+
+                _ ->
+                  state
+              end
+
+            _ ->
+              state
+          end
+
+        :error ->
+          state
+      end
+
+    {:reply, :ok, state}
+  end
+
   def handle_call({:record_heartbeats, executions, external_session_id}, _from, state) do
     # TODO: handle execution statuses?
     case Map.fetch(state.session_ids, external_session_id) do
@@ -3689,6 +3725,17 @@ defmodule Coflux.Orchestration.Server do
     {:ok, run_dependencies} = Runs.get_run_dependencies(db, run.id)
     {:ok, run_children} = Runs.get_run_children(db, run.id)
     {:ok, groups} = Runs.get_groups_for_run(db, run.id)
+    {:ok, run_metric_defs} = Runs.get_run_metric_definitions(db, run.id)
+
+    metric_definitions_by_execution =
+      Enum.group_by(
+        run_metric_defs,
+        fn {execution_id, _, _, _, _, _, _, _, _, _, _} -> execution_id end,
+        fn {_, key, group, group_units, group_lower, group_upper, scale, units, progress, lower, upper} ->
+          {key, %{group: group, group_units: group_units, group_lower: group_lower, group_upper: group_upper, scale: scale, units: units, progress: progress == 1, lower: lower, upper: upper}}
+        end
+      )
+      |> Map.new(fn {execution_id, defs} -> {execution_id, Map.new(defs)} end)
 
     cache_configs =
       steps
@@ -3816,7 +3863,8 @@ defmodule Coflux.Orchestration.Server do
                   dependencies: dependencies,
                   result: result,
                   result_created_by: result_created_by,
-                  children: Map.get(run_children, execution_id, [])
+                  children: Map.get(run_children, execution_id, []),
+                  metric_definitions: Map.get(metric_definitions_by_execution, execution_id, %{})
                 }}
              end)
          }}

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -99,12 +99,29 @@ defmodule Coflux.Topics.Run do
               {dependency_id, build_dependency(dependency)}
             end),
           children: [],
-          result: nil
+          result: nil,
+          metrics: %{}
         }
       )
     else
       topic
     end
+  end
+
+  defp process_notification(topic, {:metric_defined, execution_external_id, key, definition}) do
+    update_execution(topic, execution_external_id, fn topic, base_path ->
+      Topic.set(topic, base_path ++ [:metrics, key], %{
+        group: Map.get(definition, "group"),
+        groupUnits: Map.get(definition, "group_units"),
+        groupLower: Map.get(definition, "group_lower"),
+        groupUpper: Map.get(definition, "group_upper"),
+        scale: Map.get(definition, "scale"),
+        units: Map.get(definition, "units"),
+        progress: Map.get(definition, "progress", false),
+        lower: Map.get(definition, "lower"),
+        upper: Map.get(definition, "upper")
+      })
+    end)
   end
 
   defp process_notification(topic, {:group, execution_external_id, group_id, name}) do
@@ -236,7 +253,21 @@ defmodule Coflux.Topics.Run do
                       end),
                     dependencies: build_dependencies(execution.dependencies),
                     children: Enum.map(execution.children, &build_child(&1, run.external_id)),
-                    result: build_result(execution.result, execution.result_created_by)
+                    result: build_result(execution.result, execution.result_created_by),
+                    metrics:
+                      Map.new(execution.metric_definitions, fn {key, def_data} ->
+                        {key, %{
+                          group: def_data.group,
+                          groupUnits: def_data.group_units,
+                          groupLower: def_data.group_lower,
+                          groupUpper: def_data.group_upper,
+                          scale: def_data.scale,
+                          units: def_data.units,
+                          progress: def_data.progress,
+                          lower: def_data.lower,
+                          upper: def_data.upper
+                        }}
+                      end)
                   }}
                end)
            }}

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -256,17 +256,18 @@ defmodule Coflux.Topics.Run do
                     result: build_result(execution.result, execution.result_created_by),
                     metrics:
                       Map.new(execution.metric_definitions, fn {key, def_data} ->
-                        {key, %{
-                          group: def_data.group,
-                          groupUnits: def_data.group_units,
-                          groupLower: def_data.group_lower,
-                          groupUpper: def_data.group_upper,
-                          scale: def_data.scale,
-                          units: def_data.units,
-                          progress: def_data.progress,
-                          lower: def_data.lower,
-                          upper: def_data.upper
-                        }}
+                        {key,
+                         %{
+                           group: def_data.group,
+                           groupUnits: def_data.group_units,
+                           groupLower: def_data.group_lower,
+                           groupUpper: def_data.group_upper,
+                           scale: def_data.scale,
+                           units: def_data.units,
+                           progress: def_data.progress,
+                           lower: def_data.lower,
+                           upper: def_data.upper
+                         }}
                       end)
                   }}
                end)

--- a/server/lib/coflux/web.ex
+++ b/server/lib/coflux/web.ex
@@ -14,6 +14,7 @@ defmodule Coflux.Web do
        [
          {"/blobs/:key", Handlers.Blobs, []},
          {"/logs", Handlers.Logs, []},
+         {"/metrics", Handlers.Metrics, []},
          {"/worker", Handlers.Worker, []},
          {"/topics", Handlers.Topics.WebSocket, registry: Coflux.TopicalRegistry},
          {"/topics/[...]", Handlers.Topics.Rest, registry: Coflux.TopicalRegistry},

--- a/server/priv/migrations/metrics/1.sql
+++ b/server/priv/migrations/metrics/1.sql
@@ -1,0 +1,20 @@
+-- Metric data points
+CREATE TABLE metrics (
+  id INTEGER PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  execution_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value REAL NOT NULL,
+  at REAL NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;
+
+-- Primary query: metrics for a run, filtered by workspace and key
+CREATE INDEX idx_metrics_run_workspace_key_at ON metrics(run_id, workspace_id, key, at);
+
+-- Execution-scoped queries
+CREATE INDEX idx_metrics_execution_key_at ON metrics(execution_id, key, at);
+
+-- For rotation/cleanup
+CREATE INDEX idx_metrics_created ON metrics(created_at);

--- a/server/priv/migrations/orchestration/2.sql
+++ b/server/priv/migrations/orchestration/2.sql
@@ -1,0 +1,16 @@
+CREATE TABLE metrics (
+  id INTEGER PRIMARY KEY,
+  execution_id INTEGER NOT NULL REFERENCES executions(id),
+  key TEXT NOT NULL,
+  "group" TEXT,
+  scale TEXT,
+  units TEXT,
+  progress BOOLEAN NOT NULL DEFAULT 0,
+  lower REAL,
+  upper REAL,
+  group_units TEXT,
+  group_lower REAL,
+  group_upper REAL,
+  created_at INTEGER NOT NULL,
+  UNIQUE(execution_id, key)
+);

--- a/tests/support/server.py
+++ b/tests/support/server.py
@@ -5,8 +5,8 @@ import os
 import socket
 import subprocess
 import time
-import urllib.request
 import urllib.error
+import urllib.request
 import uuid
 
 _SERVER_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "server")


### PR DESCRIPTION
This adds initial/experimental support for metrics. An execution can define a metric and then report values, which can then be rendered in charts in Studio.

A metric can be defined simply with `metric = cf.Metric("accuracy")`, where the parameter is the 'key' of the metric. And then values are recorded with `metric.record(1.23)`, which associates the value with the time (since the execution started), or with a specific 'x' value with `metric.record(1.23, at=epoch)`.

Metrics can be associated with a specific 'group' or 'scale'. Metrics for each group are displayed in Studio on separate charts. A group can have an associate unit, and lower/upper x bounds. The scale defines the y-axis scale and units for the metric, such that different metrics on the same chart can be configured to share a y-axis.

An operation's 'progress' can also be recorded using metrics:

```python
for line in cf.progress(lines):
    ...
```

This will record a metric, and also render a progress bar on the graph, indicating the progress of the execution.

By default metrics are throttled so that they only report a value up to 10 times per second, but this can be adjusted/removed.

At the moment only a built-in metric store is supported, but in future the intention is to support integrating with other stores.