### PR TITLE
Support polling executions

### DIFF
--- a/adapters/python/CHANGELOG.md
+++ b/adapters/python/CHANGELOG.md
@@ -5,6 +5,7 @@ Enhancements:
 - Adds support for writing metrics, and writing progress.
 - Adds `timeout` parameter to `@task` and `@workflow` decorators.
 - Adds `ExecutionCancelled` and `ExecutionTimeout` exceptions.
+- Adds `.poll()` method to `Execution` for checking execution results without blocking (or suspending).
 
 ## 0.9.0
 

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -101,7 +101,12 @@ class ExecutorContext:
             raise ExecutionTimeout()
         return deserialize_value(value)
 
-    def poll_execution(self, target_execution_id: str, timeout_ms: int | None = None, default: Any = None) -> Any:
+    def poll_execution(
+        self,
+        target_execution_id: str,
+        timeout_ms: int | None = None,
+        default: Any = None,
+    ) -> Any:
         """Poll for an execution result without suspending.
 
         Returns the deserialized result if available, or `default` if not ready.

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -101,6 +101,30 @@ class ExecutorContext:
             raise ExecutionTimeout()
         return deserialize_value(value)
 
+    def poll_execution(self, target_execution_id: str, timeout_ms: int | None = None, default: Any = None) -> Any:
+        """Poll for an execution result without suspending.
+
+        Returns the deserialized result if available, or `default` if not ready.
+        """
+        request_id = protocol.request_resolve_reference(
+            self.execution_id,
+            target_execution_id,
+            timeout_ms=timeout_ms or 0,
+            suspend=False,
+        )
+        value = self._wait_response(request_id)
+        status = value.get("status")
+        if status == "not_ready":
+            return default
+        if status == "error":
+            raise create_execution_error(
+                value.get("error_type", ""),
+                value.get("error_message", ""),
+            )
+        if status == "cancelled":
+            raise ExecutionCancelled()
+        return deserialize_value(value)
+
     def get_asset_entries(self, asset_id: str) -> list[AssetEntry]:
         """Get all entries for an asset by ID."""
         request_id = protocol.request_get_asset(

--- a/adapters/python/coflux/models.py
+++ b/adapters/python/coflux/models.py
@@ -10,6 +10,7 @@ from .state import get_context
 
 
 T = t.TypeVar("T")
+D = t.TypeVar("D")
 
 
 class AssetEntry(t.NamedTuple):
@@ -126,6 +127,21 @@ class Execution(t.Generic[T]):
         """Wait for and return the execution result."""
         ctx = get_context()
         return ctx.resolve_execution(self._execution_id)
+
+    @t.overload
+    def poll(self, timeout: float | None = None) -> T | None: ...
+
+    @t.overload
+    def poll(self, timeout: float | None = None, *, default: D) -> T | D: ...
+
+    def poll(self, timeout: float | None = None, default: t.Any = None) -> t.Any:
+        """Poll for the execution result without suspending.
+
+        Returns the result if available, or ``default`` if not ready yet.
+        """
+        ctx = get_context()
+        timeout_ms = int(timeout * 1000) if timeout else None
+        return ctx.poll_execution(self._execution_id, timeout_ms, default=default)
 
     def cancel(self) -> None:
         """Cancel this execution."""

--- a/adapters/python/coflux/protocol.py
+++ b/adapters/python/coflux/protocol.py
@@ -221,6 +221,7 @@ def request_resolve_reference(
     execution_id: str,
     target_execution_id: str,
     timeout_ms: int | None = None,
+    suspend: bool = True,
 ) -> int:
     """Request to resolve a reference (get result of another execution)."""
     params: dict[str, Any] = {
@@ -229,6 +230,8 @@ def request_resolve_reference(
     }
     if timeout_ms is not None:
         params["timeout_ms"] = timeout_ms
+    if not suspend:
+        params["suspend"] = False
     return get_protocol().send_request("resolve_reference", params)
 
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,6 @@ Enhancements:
 
 - Updates `server` command to set default project ("default"), and improve Docker lifecycle handling.
 - Updates `worker` command to infer adapter (to avoid running `setup`).
-- Adds support for execution timeouts on tasks and workflows.
 
 ## 0.9.0
 

--- a/cli/internal/adapter/protocol.go
+++ b/cli/internal/adapter/protocol.go
@@ -87,7 +87,7 @@ type ErrorInfo struct {
 }
 
 // ResolveResult represents the outcome of resolving a reference.
-// Status is one of "value", "error", "cancelled", or "suspended".
+// Status is one of "value", "error", "cancelled", "suspended", or "not_ready".
 type ResolveResult struct {
 	Status       string
 	Value        *Value // set when Status == "value"
@@ -197,6 +197,7 @@ type ResolveReferenceParams struct {
 	ExecutionID       string `json:"execution_id"`
 	TargetExecutionID string `json:"target_execution_id"`
 	TimeoutMs         *int64 `json:"timeout_ms,omitempty"`
+	Suspend           *bool  `json:"suspend,omitempty"`
 }
 
 // PersistAssetParams for persist_asset request

--- a/cli/internal/pool/pool.go
+++ b/cli/internal/pool/pool.go
@@ -17,7 +17,7 @@ type ExecutionHandler interface {
 	// SubmitExecution submits a child execution
 	SubmitExecution(ctx context.Context, params *adapter.SubmitExecutionParams) (map[string]any, error)
 	// ResolveReference resolves a reference to get its result
-	ResolveReference(ctx context.Context, executionID string, targetExecutionID string, timeoutMs *int64) (*adapter.ResolveResult, error)
+	ResolveReference(ctx context.Context, executionID string, targetExecutionID string, timeoutMs *int64, suspend *bool) (*adapter.ResolveResult, error)
 	// PersistAsset persists files as an asset
 	PersistAsset(ctx context.Context, executionID string, paths []string, metadata map[string]any, preResolved map[string][]any) (map[string]any, error)
 	// GetAsset retrieves asset entries
@@ -450,7 +450,7 @@ func (p *Pool) handleRequest(ctx context.Context, exec *adapter.Executor, method
 			errInfo = &adapter.ErrorInfo{Code: "parse_error", Message: err.Error()}
 			break
 		}
-		resolved, err := p.handler.ResolveReference(ctx, req.ExecutionID, req.TargetExecutionID, req.TimeoutMs)
+		resolved, err := p.handler.ResolveReference(ctx, req.ExecutionID, req.TargetExecutionID, req.TimeoutMs, req.Suspend)
 		if err != nil {
 			errInfo = &adapter.ErrorInfo{Code: "resolve_error", Message: err.Error()}
 		} else {
@@ -469,6 +469,8 @@ func (p *Pool) handleRequest(ctx context.Context, exec *adapter.Executor, method
 				result = map[string]any{"status": "timeout"}
 			case "suspended":
 				result = map[string]any{"status": "suspended"}
+			case "not_ready":
+				result = map[string]any{"status": "not_ready"}
 			}
 		}
 

--- a/cli/internal/worker/worker.go
+++ b/cli/internal/worker/worker.go
@@ -781,12 +781,12 @@ func (w *Worker) processReferences(refs [][]any) ([]any, error) {
 	return result, nil
 }
 
-func (w *Worker) ResolveReference(ctx context.Context, executionID string, targetExecutionID string, timeoutMs *int64) (*adapter.ResolveResult, error) {
+func (w *Worker) ResolveReference(ctx context.Context, executionID string, targetExecutionID string, timeoutMs *int64, suspend *bool) (*adapter.ResolveResult, error) {
 	conn, err := w.requireConn()
 	if err != nil {
 		return nil, err
 	}
-	result, err := conn.Request(ctx, "get_result", targetExecutionID, executionID, timeoutMs)
+	result, err := conn.Request(ctx, "get_result", targetExecutionID, executionID, timeoutMs, suspend)
 	if err != nil {
 		return nil, err
 	}
@@ -859,6 +859,8 @@ func (w *Worker) ResolveReference(ctx context.Context, executionID string, targe
 			return &adapter.ResolveResult{Status: "timeout"}, nil
 		case "suspended":
 			return &adapter.ResolveResult{Status: "suspended"}, nil
+		case "not_ready":
+			return &adapter.ResolveResult{Status: "not_ready"}, nil
 		}
 	}
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,6 +4,7 @@ Enhancements:
 
 - Adds support for storing metrics and their definitions.
 - Adds support for execution timeouts on tasks and workflows.
+- Adds `suspend` flag to `get_result` for non-suspending result polling.
 
 ## 0.9.0
 

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -317,7 +317,11 @@ defmodule Coflux.Handlers.Worker do
         end
 
       "get_result" ->
-        [execution_id, from_execution_id, timeout_ms] = message["params"]
+        {execution_id, from_execution_id, timeout_ms, suspend} =
+          case message["params"] do
+            [eid, feid, tms, s] -> {eid, feid, tms, s}
+            [eid, feid, tms] -> {eid, feid, tms, true}
+          end
 
         if is_recognised_execution?(from_execution_id, state) do
           case Orchestration.get_result(
@@ -325,6 +329,7 @@ defmodule Coflux.Handlers.Worker do
                  execution_id,
                  from_execution_id,
                  timeout_ms,
+                 suspend,
                  message["id"]
                ) do
             {:ok, result} ->
@@ -568,6 +573,7 @@ defmodule Coflux.Handlers.Worker do
       :cancelled -> ["cancelled"]
       {:timeout, nil} -> ["timeout"]
       :suspended -> ["suspended"]
+      :not_ready -> ["not_ready"]
     end
   end
 

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -157,10 +157,10 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:record_result, execution_id, result})
   end
 
-  def get_result(project_id, execution_id, from_execution_id, timeout_ms, request_id) do
+  def get_result(project_id, execution_id, from_execution_id, timeout_ms, suspend, request_id) do
     call_server(
       project_id,
-      {:get_result, execution_id, from_execution_id, timeout_ms, request_id}
+      {:get_result, execution_id, from_execution_id, timeout_ms, suspend, request_id}
     )
   end
 

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -84,7 +84,7 @@ defmodule Coflux.Orchestration.Server do
               # topic -> [notification]
               notifications: %{},
 
-              # execution_external_id -> [{from_execution_external_id, request_id, suspend_at}]
+              # execution_external_id -> [{from_execution_external_id, request_id, expire_at, suspend?}]
               waiting: %{},
 
               # task_ref -> callback
@@ -1506,7 +1506,8 @@ defmodule Coflux.Orchestration.Server do
   end
 
   def handle_call(
-        {:get_result, execution_external_id, from_execution_external_id, timeout_ms, request_id},
+        {:get_result, execution_external_id, from_execution_external_id, timeout_ms, suspend,
+         request_id},
         _from,
         state
       ) do
@@ -1563,8 +1564,9 @@ defmodule Coflux.Orchestration.Server do
         {result, state} =
           case resolve_result(state.db, execution_id) do
             {:pending, pending_execution_id} ->
-              state =
-                if timeout_ms == 0 do
+              cond do
+                timeout_ms == 0 && suspend ->
+                  # Immediate suspend
                   {:ok, state} =
                     process_result(
                       state,
@@ -1572,10 +1574,16 @@ defmodule Coflux.Orchestration.Server do
                       {:suspended, nil, [pending_execution_id]}
                     )
 
-                  state
-                else
+                  {:wait, state}
+
+                timeout_ms == 0 ->
+                  # Immediate poll: return not_ready
+                  {{:ok, :not_ready}, state}
+
+                true ->
+                  # Wait for result (with or without timeout)
                   now = System.monotonic_time(:millisecond)
-                  suspend_at = if timeout_ms, do: now + timeout_ms
+                  expire_at = if timeout_ms, do: now + timeout_ms
 
                   # Use the external ID of the *resolved* pending execution as the waiting key.
                   # This is critical for spawned chains: resolve_result follows
@@ -1590,17 +1598,18 @@ defmodule Coflux.Orchestration.Server do
                     update_in(
                       state,
                       [Access.key(:waiting), Access.key(pending_ext_id, [])],
-                      &[{from_execution_external_id, request_id, suspend_at} | &1]
+                      &[{from_execution_external_id, request_id, expire_at, suspend} | &1]
                     )
 
-                  if timeout_ms do
-                    reschedule_next_suspend(state)
-                  else
-                    state
-                  end
-                end
+                  state =
+                    if timeout_ms do
+                      reschedule_next_suspend(state)
+                    else
+                      state
+                    end
 
-              {:wait, state}
+                  {:wait, state}
+              end
 
             {:ok, result} ->
               # Only enrich value results with resolved references (asset metadata, execution metadata)
@@ -2630,30 +2639,67 @@ defmodule Coflux.Orchestration.Server do
     now = System.monotonic_time(:millisecond)
 
     # waiting map now uses external IDs
-    # suspended: from_ext_id -> [dependency_ext_id]
-    suspended =
+    # Collect expired entries, grouped by from_ext_id with their suspend flag
+    {to_suspend, to_notify_not_ready} =
       Enum.reduce(
         state.waiting,
-        %{},
-        fn {execution_ext_id, execution_waiting}, suspended ->
+        {%{}, []},
+        fn {execution_ext_id, execution_waiting}, {to_suspend, to_notify} ->
           Enum.reduce(
             execution_waiting,
-            suspended,
-            fn {from_ext_id, _, suspend_at}, suspended ->
-              if suspend_at && suspend_at <= now do
-                Map.update(suspended, from_ext_id, [execution_ext_id], &[execution_ext_id | &1])
+            {to_suspend, to_notify},
+            fn {from_ext_id, request_id, expire_at, suspend_flag}, {to_suspend, to_notify} ->
+              if expire_at && expire_at <= now do
+                if suspend_flag do
+                  {Map.update(to_suspend, from_ext_id, [execution_ext_id], &[execution_ext_id | &1]),
+                   to_notify}
+                else
+                  {to_suspend, [{from_ext_id, request_id} | to_notify]}
+                end
               else
-                suspended
+                {to_suspend, to_notify}
               end
             end
           )
         end
       )
 
-    # Resolve external IDs to internal for process_result
+    # Remove expired entries from waiting map
+    state =
+      update_in(state, [Access.key(:waiting)], fn waiting ->
+        waiting
+        |> Enum.map(fn {ext_id, entries} ->
+          remaining =
+            Enum.reject(entries, fn {_, _, expire_at, _} ->
+              expire_at && expire_at <= now
+            end)
+
+          {ext_id, remaining}
+        end)
+        |> Enum.reject(fn {_, entries} -> entries == [] end)
+        |> Map.new()
+      end)
+
+    # Handle poll (non-suspend) timeouts: send not_ready response
     state =
       Enum.reduce(
-        suspended,
+        to_notify_not_ready,
+        state,
+        fn {from_ext_id, request_id}, state ->
+          case find_session_for_execution(state, from_ext_id) do
+            {:ok, session_id} ->
+              send_session(state, session_id, {:result, request_id, :not_ready})
+
+            :error ->
+              state
+          end
+        end
+      )
+
+    # Resolve external IDs to internal for process_result (suspend cases)
+    state =
+      Enum.reduce(
+        to_suspend,
         state,
         fn {from_ext_id, dependency_ext_ids}, state ->
           from_execution_id = Map.fetch!(state.execution_ids, from_ext_id)
@@ -5025,10 +5071,10 @@ defmodule Coflux.Orchestration.Server do
       state.waiting
       |> Map.values()
       |> Enum.flat_map(fn execution_waiting ->
-        Enum.map(execution_waiting, fn {_, _, suspend_at} -> suspend_at end)
+        Enum.map(execution_waiting, fn {_, _, expire_at, _} -> expire_at end)
       end)
       |> Enum.reject(&is_nil/1)
-      |> Enum.max(fn -> nil end)
+      |> Enum.min(fn -> nil end)
 
     timer =
       if next_suspend_at do
@@ -5082,7 +5128,7 @@ defmodule Coflux.Orchestration.Server do
             Enum.reduce(
               execution_waiting,
               state,
-              fn {from_ext_id, request_id, _}, state ->
+              fn {from_ext_id, request_id, _, _}, state ->
                 # find_session_for_execution now uses external IDs
                 case find_session_for_execution(state, from_ext_id) do
                   {:ok, session_id} ->
@@ -5128,12 +5174,12 @@ defmodule Coflux.Orchestration.Server do
         {state, []},
         fn {for_ext_id, execution_waiting}, {state, pending} ->
           {removed, remaining} =
-            Enum.split_with(execution_waiting, fn {from_ext_id, _, _} ->
+            Enum.split_with(execution_waiting, fn {from_ext_id, _, _, _} ->
               from_ext_id == execution_ext_id
             end)
 
           pending =
-            Enum.reduce(removed, pending, fn {_, request_id, _}, acc ->
+            Enum.reduce(removed, pending, fn {_, request_id, _, _}, acc ->
               if request_id, do: [request_id | acc], else: acc
             end)
 

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -2651,8 +2651,12 @@ defmodule Coflux.Orchestration.Server do
             fn {from_ext_id, request_id, expire_at, suspend_flag}, {to_suspend, to_notify} ->
               if expire_at && expire_at <= now do
                 if suspend_flag do
-                  {Map.update(to_suspend, from_ext_id, [execution_ext_id], &[execution_ext_id | &1]),
-                   to_notify}
+                  {Map.update(
+                     to_suspend,
+                     from_ext_id,
+                     [execution_ext_id],
+                     &[execution_ext_id | &1]
+                   ), to_notify}
                 else
                   {to_suspend, [{from_ext_id, request_id} | to_notify]}
                 end

--- a/tests/support/executor.py
+++ b/tests/support/executor.py
@@ -100,6 +100,18 @@ class ExecutorConnection:
         resp = self._request(msg)
         return resp.get("result", resp.get("error"))
 
+    def poll(self, execution_id, target_execution_id, timeout_ms=0):
+        """Poll for a reference result without suspending.
+
+        Returns the result dict, or {"status": "not_ready"} if not yet available.
+        """
+        msg = protocol.resolve_reference_request(
+            None, execution_id, target_execution_id,
+            timeout_ms=timeout_ms, suspend=False,
+        )
+        resp = self._request(msg)
+        return resp.get("result", resp.get("error"))
+
     def cancel(self, execution_id, target_execution_id):
         """Cancel a child execution."""
         msg = protocol.cancel_execution_request(None, execution_id, target_execution_id)

--- a/tests/support/protocol.py
+++ b/tests/support/protocol.py
@@ -103,14 +103,19 @@ def submit_execution_request(
     return {"id": request_id, "method": "submit_execution", "params": params}
 
 
-def resolve_reference_request(request_id, execution_id, target_execution_id):
+def resolve_reference_request(request_id, execution_id, target_execution_id, timeout_ms=None, suspend=None):
+    params = {
+        "execution_id": execution_id,
+        "target_execution_id": target_execution_id,
+    }
+    if timeout_ms is not None:
+        params["timeout_ms"] = timeout_ms
+    if suspend is not None:
+        params["suspend"] = suspend
     return {
         "id": request_id,
         "method": "resolve_reference",
-        "params": {
-            "execution_id": execution_id,
-            "target_execution_id": target_execution_id,
-        },
+        "params": params,
     }
 
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -479,3 +479,125 @@ def test_cancel_across_multiple_spawns(worker):
         # Run result should be cancelled
         result = ctx.result(run_id)
         assert result["type"] == "cancelled"
+
+
+def test_poll_returns_not_ready_when_pending(worker):
+    """Polling a pending execution returns not_ready without suspending."""
+    targets = [
+        workflow("test", "main"),
+        task("test", "slow"),
+    ]
+
+    with worker(targets, concurrency=2) as ctx:
+        resp = ctx.submit("test", "main")
+        run_id = resp["runId"]
+
+        ex0 = ctx.executor.next_execute()
+        ref = ex0.conn.submit_task(ex0.execution_id, "test", "slow", json_args(1))
+
+        # Task is dispatched but not yet complete
+        ex1 = ctx.executor.next_execute()
+        assert ex1.target == "slow"
+
+        # Poll should return not_ready (task hasn't completed)
+        result = ex0.conn.poll(ex0.execution_id, ref)
+        assert result == {"status": "not_ready"}
+
+        # Complete the task
+        ex1.conn.complete(ex1.execution_id, value=42)
+
+        # Now resolve should return the value
+        resolved = ex0.conn.resolve(ex0.execution_id, ref)
+        assert resolved["value"] == 42
+
+        ex0.conn.complete(ex0.execution_id, value="done")
+        assert ctx.result(run_id)["value"]["data"] == "done"
+
+
+def test_poll_returns_value_when_ready(worker):
+    """Polling an already-completed execution returns the value immediately."""
+    targets = [
+        workflow("test", "main"),
+        task("test", "fast"),
+    ]
+
+    with worker(targets, concurrency=2) as ctx:
+        resp = ctx.submit("test", "main")
+        run_id = resp["runId"]
+
+        ex0 = ctx.executor.next_execute()
+        ref = ex0.conn.submit_task(ex0.execution_id, "test", "fast", json_args(1))
+
+        # Complete the task before polling
+        ex1 = ctx.executor.next_execute()
+        ex1.conn.complete(ex1.execution_id, value=99)
+
+        # Poll with a timeout so the server returns the value once it's processed
+        result = ex0.conn.poll(ex0.execution_id, ref, timeout_ms=5000)
+        assert result["value"] == 99
+
+        ex0.conn.complete(ex0.execution_id, value="done")
+        assert ctx.result(run_id)["value"]["data"] == "done"
+
+
+def test_poll_with_timeout_waits_then_returns_not_ready(worker):
+    """Poll with a timeout waits for the specified duration before returning not_ready."""
+    targets = [
+        workflow("test", "main"),
+        task("test", "slow"),
+    ]
+
+    with worker(targets, concurrency=2) as ctx:
+        resp = ctx.submit("test", "main")
+        run_id = resp["runId"]
+
+        ex0 = ctx.executor.next_execute()
+        ref = ex0.conn.submit_task(ex0.execution_id, "test", "slow", json_args(1))
+
+        ex1 = ctx.executor.next_execute()
+
+        # Poll with a short timeout -- task is still running
+        start = time.time()
+        result = ex0.conn.poll(ex0.execution_id, ref, timeout_ms=500)
+        elapsed = time.time() - start
+        assert result == {"status": "not_ready"}
+        assert elapsed >= 0.4, f"expected >=0.4s wait, got {elapsed:.2f}s"
+
+        # Complete the task and resolve normally
+        ex1.conn.complete(ex1.execution_id, value=77)
+        resolved = ex0.conn.resolve(ex0.execution_id, ref)
+        assert resolved["value"] == 77
+
+        ex0.conn.complete(ex0.execution_id, value="done")
+        assert ctx.result(run_id)["value"]["data"] == "done"
+
+
+def test_poll_with_timeout_returns_value_if_ready_before_timeout(worker):
+    """Poll with a timeout returns the value if it becomes available before the timeout."""
+    targets = [
+        workflow("test", "main"),
+        task("test", "quick"),
+    ]
+
+    with worker(targets, concurrency=2) as ctx:
+        resp = ctx.submit("test", "main")
+        run_id = resp["runId"]
+
+        ex0 = ctx.executor.next_execute()
+        ref = ex0.conn.submit_task(ex0.execution_id, "test", "quick", json_args(1))
+
+        ex1 = ctx.executor.next_execute()
+
+        # Complete the task, then poll with a long timeout
+        ex1.conn.complete(ex1.execution_id, value=55)
+
+        start = time.time()
+        result = ex0.conn.poll(ex0.execution_id, ref, timeout_ms=5000)
+        elapsed = time.time() - start
+
+        # Should return with the value well before the 5s timeout
+        assert result["value"] == 55
+        assert elapsed < 2, f"expected fast return, got {elapsed:.2f}s"
+
+        ex0.conn.complete(ex0.execution_id, value="done")
+        assert ctx.result(run_id)["value"]["data"] == "done"


### PR DESCRIPTION
This adds support for polling executions (from tasks/workflows) to determine whether a result is ready (without blocking or suspending):

```python
execution = slow_task.submit()
while (result := execution.poll(timeout=1)) is None:
    print("waiting...")
```