### PR TITLE
Support gracefully draining workers with timeout

### DIFF
--- a/cli/cmd/coflux/worker.go
+++ b/cli/cmd/coflux/worker.go
@@ -37,14 +37,15 @@ Examples:
 }
 
 var (
-	workerWatch       bool
-	workerRegister    bool
-	workerDev         bool
-	workerConcurrency int
-	workerSession     string
-	workerProvides    []string
-	workerAccepts     []string
-	workerAdapter     []string
+	workerWatch        bool
+	workerRegister     bool
+	workerDev          bool
+	workerConcurrency  int
+	workerSession      string
+	workerProvides     []string
+	workerAccepts      []string
+	workerAdapter      []string
+	workerDrainTimeout time.Duration
 )
 
 func init() {
@@ -56,6 +57,7 @@ func init() {
 	workerCmd.Flags().StringSliceVar(&workerProvides, "provides", nil, "Features that this worker provides (e.g., --provides gpu:A100,gpu:H100,region:eu)")
 	workerCmd.Flags().StringSliceVar(&workerAccepts, "accepts", nil, "Tags that executions must have to be scheduled on this worker (e.g., --accepts priority:high)")
 	workerCmd.Flags().StringSliceVar(&workerAdapter, "adapter", nil, "Adapter command (e.g., --adapter python,-m,coflux)")
+	workerCmd.Flags().DurationVar(&workerDrainTimeout, "drain-timeout", 2*time.Minute, "How long to wait for in-flight executions to finish before aborting them on shutdown or reload. 0 means wait indefinitely. Signal again to abort the drain early.")
 }
 
 func runWorker(cmd *cobra.Command, args []string) error {
@@ -133,18 +135,26 @@ func runWorker(cmd *cobra.Command, args []string) error {
 	// Create worker
 	w := worker.New(cfg, cmdAdapter, session, logger)
 
-	// Setup signal handling
+	// Setup signal handling with three phases:
+	//   1st signal: close shutdownCh — triggers a graceful drain
+	//   2nd signal: close drainAbortCh — aborts the drain early (kill in-flight)
+	//   3rd signal: os.Exit — last resort if shutdown itself is stuck
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
+
+	shutdownCh := make(chan struct{})
+	drainAbortCh := make(chan struct{})
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		<-sigCh
-		logger.Info("shutting down...")
-		cancel()
-		// Second signal: force exit (shutdown is stuck)
+		logger.Info("shutting down (signal again to abort drain early)")
+		close(shutdownCh)
+		<-sigCh
+		logger.Warn("aborting drain")
+		close(drainAbortCh)
 		<-sigCh
 		logger.Error("forced shutdown")
 		os.Exit(1)
@@ -157,7 +167,7 @@ func runWorker(cmd *cobra.Command, args []string) error {
 	shouldWatch := workerWatch || workerDev
 
 	if shouldWatch {
-		return runWorkerWithWatch(ctx, cfg, cmdAdapter, session, modules, shouldRegister, logger)
+		return runWorkerWithWatch(ctx, cfg, cmdAdapter, session, modules, shouldRegister, shutdownCh, drainAbortCh, logger)
 	}
 
 	// Run worker
@@ -169,20 +179,54 @@ func runWorker(cmd *cobra.Command, args []string) error {
 		"register", shouldRegister,
 	)
 
-	if err := w.Run(ctx, modules, shouldRegister); err != nil {
-		if ctx.Err() != nil {
-			// Normal shutdown
-			logger.Info("worker stopped")
-			return nil
-		}
-		return fmt.Errorf("worker error: %w", err)
-	}
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- w.Run(ctx, modules, shouldRegister)
+	}()
 
-	return nil
+	select {
+	case <-shutdownCh:
+		drainWorker(w, workerDrainTimeout, drainAbortCh, logger)
+		cancel()
+		<-workerDone
+		logger.Info("worker stopped")
+		return nil
+	case err := <-workerDone:
+		if err != nil {
+			return fmt.Errorf("worker error: %w", err)
+		}
+		return nil
+	}
+}
+
+// drainWorker runs a graceful drain with the configured timeout, aborting
+// early if abortCh is closed.
+func drainWorker(w *worker.Worker, timeout time.Duration, abortCh <-chan struct{}, logger *slog.Logger) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-abortCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	if timeout > 0 {
+		logger.Info("draining in-flight executions", "timeout", timeout)
+	} else {
+		logger.Info("draining in-flight executions (no timeout; signal again to abort)")
+	}
+	if remaining := w.Drain(ctx, timeout); remaining > 0 {
+		logger.Warn("drain incomplete; aborting executions", "remaining", remaining)
+	} else {
+		logger.Info("drain complete")
+	}
 }
 
 // runWorkerWithWatch runs the worker with file watching enabled.
-// When Python files change, the worker is restarted.
+// When Python files change, the worker is restarted (with a graceful
+// drain in between). Closing shutdownCh triggers the same drain-then-stop
+// path; closing drainAbortCh aborts any in-flight drain early.
 func runWorkerWithWatch(
 	ctx context.Context,
 	cfg *config.Config,
@@ -190,6 +234,8 @@ func runWorkerWithWatch(
 	session string,
 	modules []string,
 	shouldRegister bool,
+	shutdownCh <-chan struct{},
+	drainAbortCh <-chan struct{},
 	logger *slog.Logger,
 ) error {
 	// Create file watcher
@@ -221,8 +267,8 @@ func runWorkerWithWatch(
 		workerDone := make(chan error, 1)
 
 		// Start worker in goroutine
+		w := worker.New(cfg, cmdAdapter, session, logger)
 		go func() {
-			w := worker.New(cfg, cmdAdapter, session, logger)
 			logger.Info("starting worker",
 				"workspace", cfg.Workspace,
 				"host", cfg.Host,
@@ -232,22 +278,15 @@ func runWorkerWithWatch(
 			workerDone <- w.Run(runCtx, modules, shouldRegister)
 		}()
 
-		// Wait for Python file change, signal, or worker exit
-		restart := false
-		for !restart {
+		// Wait for a file change, shutdown, or worker exit.
+		reason := ""
+		for reason == "" {
 			select {
-			case <-ctx.Done():
-				logger.Info("shutting down...")
-				runCancel()
-				<-workerDone
-				return nil
+			case <-shutdownCh:
+				reason = "shutdown"
 
 			case err := <-workerDone:
 				runCancel()
-				if ctx.Err() != nil {
-					logger.Info("worker stopped")
-					return nil
-				}
 				if err != nil {
 					return fmt.Errorf("worker error: %w", err)
 				}
@@ -256,7 +295,7 @@ func runWorkerWithWatch(
 			case event := <-watcher.Events:
 				if isPythonFileChange(event) {
 					logger.Info("change detected, reloading...", "file", event.Name)
-					restart = true
+					reason = "reload"
 				}
 				// For non-Python changes, continue waiting
 
@@ -265,19 +304,17 @@ func runWorkerWithWatch(
 			}
 		}
 
-		// Restart: cancel current worker and wait for it to stop
+		// Drain in-flight executions (keeps the WebSocket open so results
+		// can still be reported), then tear down.
+		drainWorker(w, workerDrainTimeout, drainAbortCh, logger)
 		runCancel()
-		select {
-		case <-workerDone:
-		case <-ctx.Done():
-			// Signal received during reload cleanup — wait briefly
-			select {
-			case <-workerDone:
-			case <-time.After(5 * time.Second):
-				logger.Warn("worker cleanup timed out during shutdown")
-			}
+		<-workerDone
+
+		if reason == "shutdown" {
+			logger.Info("worker stopped")
 			return nil
 		}
+
 		// Small delay to let file writes complete
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/cli/internal/pool/pool.go
+++ b/cli/internal/pool/pool.go
@@ -67,7 +67,8 @@ type Pool struct {
 	warm     []*adapter.Executor          // idle, ready executors
 	busy     map[string]*adapter.Executor // executionID -> running executor
 	aborted  map[string]bool              // executions aborted by the server
-	shutdown bool
+	draining bool                         // set during Drain: skip warm spawning, but still accept Execute
+	shutdown bool                         // set during Stop: refuse Execute entirely
 	cancel   context.CancelFunc
 	ctx      context.Context
 	wg       sync.WaitGroup // tracks runExecution goroutines
@@ -154,11 +155,14 @@ func (p *Pool) Execute(ctx context.Context, executionID, module, target string, 
 		}
 	}
 
+	// Add to busy and wg under the same mutex so Drain can observe both
+	// atomically (otherwise Drain can read busy=0 before wg is incremented,
+	// race wg.Wait, and miss an in-flight execution).
 	p.mu.Lock()
 	p.busy[executionID] = exec
+	p.wg.Add(1)
 	p.mu.Unlock()
 
-	p.wg.Add(1)
 	go p.runExecution(ctx, exec, executionID, module, target, arguments, timeoutMs)
 
 	return nil
@@ -313,7 +317,7 @@ func (p *Pool) finishExecution(executionID string, execToClose *adapter.Executor
 // concurrency limit. Failures are silently ignored — warming is best-effort.
 func (p *Pool) tryWarm() {
 	p.mu.Lock()
-	if p.shutdown || len(p.warm)+len(p.busy) >= p.concurrency || len(p.warm) >= p.warmTarget {
+	if p.shutdown || p.draining || len(p.warm)+len(p.busy) >= p.concurrency || len(p.warm) >= p.warmTarget {
 		p.mu.Unlock()
 		return
 	}
@@ -329,7 +333,7 @@ func (p *Pool) tryWarm() {
 	defer p.mu.Unlock()
 
 	// Re-check limits after spawning (another execution may have started)
-	if p.shutdown || len(p.warm)+len(p.busy) >= p.concurrency || len(p.warm) >= p.warmTarget {
+	if p.shutdown || p.draining || len(p.warm)+len(p.busy) >= p.concurrency || len(p.warm) >= p.warmTarget {
 		_ = exec.Close()
 		return
 	}
@@ -623,6 +627,61 @@ func (p *Pool) Abort(executionID string) error {
 
 	_ = exec.Close()
 	return nil
+}
+
+// Drain marks the pool as draining (stops spawning warm executors),
+// closes any existing warm executors, and waits up to timeout for
+// in-flight executions to finish on their own. A timeout of 0 means
+// wait indefinitely (until ctx is cancelled). Execute calls still
+// succeed during drain — late-arriving assignments (from the race
+// window between signalling the server and the server acting on it)
+// will start fresh executor processes and run normally. Returns the
+// number of executions still running when the drain ended (0 if
+// everything finished cleanly). Safe to call multiple times.
+//
+// The drain aborts early if ctx is cancelled.
+//
+// Stop must still be called afterwards to tear down anything that
+// didn't finish within the timeout and to clean up pool resources.
+func (p *Pool) Drain(ctx context.Context, timeout time.Duration) int {
+	p.mu.Lock()
+	warm := p.warm
+	p.warm = nil
+	busyCount := len(p.busy)
+	p.draining = true
+	p.mu.Unlock()
+
+	// Warm executors are idle — close them now.
+	for _, exec := range warm {
+		_ = exec.Close()
+	}
+
+	if busyCount == 0 {
+		return 0
+	}
+
+	drainCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		drainCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return 0
+	case <-drainCtx.Done():
+		p.mu.Lock()
+		remaining := len(p.busy)
+		p.mu.Unlock()
+		return remaining
+	}
 }
 
 // Stop shuts down the pool. Closes all warm and busy executors and waits for

--- a/cli/internal/worker/worker.go
+++ b/cli/internal/worker/worker.go
@@ -150,6 +150,30 @@ func (w *Worker) requireConn() (*api.Connection, error) {
 	return conn, nil
 }
 
+// Drain waits for in-flight executions to finish, up to timeout. New
+// executions are refused once Drain has been called. Returns the number
+// of executions still running when the drain ended. The drain aborts
+// early if ctx is cancelled.
+//
+// The WebSocket stays open so in-flight executions can still report
+// results. Cancel the context passed to Run afterwards to tear
+// everything down.
+func (w *Worker) Drain(ctx context.Context, timeout time.Duration) int {
+	if w.pool == nil {
+		return 0
+	}
+	// Signal to the server that this session is draining — the server
+	// will stop routing new work here. Any execute messages already in
+	// flight (the race window between sending this and the server
+	// acting on it) still run normally.
+	if conn := w.getConn(); conn != nil {
+		if err := conn.Notify("session_draining"); err != nil {
+			w.logger.Warn("failed to send session_draining", "error", err)
+		}
+	}
+	return w.pool.Drain(ctx, timeout)
+}
+
 // Run starts the worker
 func (w *Worker) Run(ctx context.Context, modules []string, register bool) error {
 	// Create API client

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -97,6 +97,10 @@ defmodule Coflux.Handlers.Worker do
             {[], state}
         end
 
+      "session_draining" ->
+        :ok = Orchestration.session_draining(state.project_id, state.session_id)
+        {[], state}
+
       "register_group" ->
         [parent_id, group_id, name] = message["params"]
 

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -127,6 +127,10 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:declare_targets, session_id, targets, concurrency})
   end
 
+  def session_draining(project_id, session_id) do
+    call_server(project_id, {:session_draining, session_id})
+  end
+
   def start_run(project_id, module, target, type, arguments, access \\ nil, opts \\ []) do
     call_server(project_id, {:start_run, module, target, type, arguments, access, opts})
   end

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -257,6 +257,7 @@ defmodule Coflux.Orchestration.Server do
             starting: MapSet.new(),
             executing: MapSet.new(),
             concurrency: 0,
+            draining: false,
             workspace_id: workspace_id,
             provides: provides,
             accepts: accepts,
@@ -1072,6 +1073,7 @@ defmodule Coflux.Orchestration.Server do
             starting: MapSet.new(),
             executing: MapSet.new(),
             concurrency: 0,
+            draining: false,
             workspace_id: workspace_id,
             provides: provides,
             accepts: accepts,
@@ -1221,6 +1223,27 @@ defmodule Coflux.Orchestration.Server do
     send(self(), :tick)
 
     {:reply, :ok, state}
+  end
+
+  def handle_call({:session_draining, external_id}, _from, state) do
+    case Map.fetch(state.session_ids, external_id) do
+      {:ok, session_id} ->
+        state = put_in(state, [Access.key(:sessions), session_id, :draining], true)
+        session = Map.fetch!(state.sessions, session_id)
+
+        state =
+          state
+          |> notify_listeners(
+            {:sessions, workspace_external_id(state, session.workspace_id)},
+            {:session, session.external_id, build_session_data(state, session)}
+          )
+          |> flush_notifications()
+
+        {:reply, :ok, state}
+
+      :error ->
+        {:reply, :ok, state}
+    end
   end
 
   def handle_call({:start_run, module, target_name, type, arguments, access, opts}, _from, state) do
@@ -3112,6 +3135,7 @@ defmodule Coflux.Orchestration.Server do
                   starting: MapSet.new(),
                   executing: MapSet.new(),
                   concurrency: 0,
+                  draining: false,
                   workspace_id: workspace_id,
                   provides: pool.provides,
                   accepts: pool_accepts,
@@ -6421,6 +6445,7 @@ defmodule Coflux.Orchestration.Server do
           session = Map.fetch!(state.sessions, session_id)
 
           session.workspace_id == execution.workspace_id && session.connection &&
+            !Map.get(session, :draining, false) &&
             !session_at_capacity?(session) &&
             session_active?(session, state) &&
             !session_pool_disabled?(session, state) &&


### PR DESCRIPTION
This updates workers to allow them to more gracefully drain executions when they're being stopped. This includes in `--dev` mode, after detecting file changes. The worker notifies the server that they're draining so they don't get assigned more executions, and then the executions in progress are given the configured time to complete before being killed.