### PR TITLE
Resolve executions/inputs with 'select'

### DIFF
--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -122,7 +122,7 @@ def select(
 
     winner_idx = get_context().select(list(handles), cancel_remaining=cancel_remaining)
     if winner_idx is None:
-        raise ExecutionTimeout()
+        raise TimeoutError("timed out waiting for any handle to resolve")
 
     winner = handles[winner_idx]
     remaining = [h for i, h in enumerate(handles) if i != winner_idx]

--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "suspense",
     "suspend",
     "select",
+    "cancel",
     "log_debug",
     "log_info",
     "log_warning",
@@ -122,6 +123,16 @@ def select(
     winner = handles[winner_idx]
     remaining = [h for i, h in enumerate(handles) if i != winner_idx]
     return winner, remaining
+
+
+def cancel(handles: list[Execution | Input]) -> None:
+    """Cancel one or more handles (executions and/or inputs) atomically.
+
+    Executions are cancelled recursively (descendants too). Inputs
+    transition to a terminal ``cancelled`` state, distinct from
+    ``dismissed``. Handles that are already resolved are silently skipped.
+    """
+    get_context().cancel(handles)
 
 
 def suspend(delay: float | dt.timedelta | dt.datetime | None = None) -> None:

--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -8,6 +8,7 @@ of targets.
 from __future__ import annotations
 
 import datetime as dt
+import typing as t
 from pathlib import Path
 
 from .prompt import Prompt
@@ -89,15 +90,18 @@ def suspense(timeout: float | None = None):
     return get_context().suspense(timeout)
 
 
+_H = t.TypeVar("_H", bound="Execution[t.Any] | Input[t.Any]")
+
+
 def select(
-    handles: list[Execution | Input],
+    handles: t.Sequence[_H],
     *,
     cancel_remaining: bool = False,
-) -> tuple[Execution | Input, list[Execution | Input]]:
+) -> tuple[_H, list[_H]]:
     """Wait for the first of one or more handles (executions/inputs) to resolve.
 
     Args:
-        handles: List of Execution and/or Input objects. Must be non-empty.
+        handles: Sequence of Execution and/or Input objects. Must be non-empty.
         cancel_remaining: If True, cancel non-winner execution handles
             atomically once a handle resolves. Input handles are left pending.
 
@@ -116,7 +120,7 @@ def select(
     if not handles:
         raise ValueError("select requires at least one handle")
 
-    winner_idx = get_context().select(handles, cancel_remaining=cancel_remaining)
+    winner_idx = get_context().select(list(handles), cancel_remaining=cancel_remaining)
     if winner_idx is None:
         raise ExecutionTimeout()
 
@@ -125,7 +129,7 @@ def select(
     return winner, remaining
 
 
-def cancel(handles: list[Execution | Input]) -> None:
+def cancel(handles: t.Sequence[Execution[t.Any] | Input[t.Any]]) -> None:
     """Cancel one or more handles (executions and/or inputs) atomically.
 
     Executions are cancelled recursively (descendants too). Inputs

--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -11,14 +11,21 @@ import datetime as dt
 import typing as t
 from pathlib import Path
 
-from .prompt import Prompt
 from ._version import __version__
-from .decorators import task, workflow, stub
-from .target import Cache, Defer, Retries
-from .errors import ExecutionCancelled, ExecutionError, ExecutionTimeout, InputDismissed
+from .decorators import stub, task, workflow
+from .errors import (
+    ExecutionAbandoned,
+    ExecutionCancelled,
+    ExecutionError,
+    ExecutionTerminated,
+    ExecutionTimeout,
+    InputDismissed,
+)
 from .metric import Metric, MetricGroup, MetricScale, progress
 from .models import Asset, AssetEntry, AssetMetadata, Execution, Input, ModelSchema
+from .prompt import Prompt
 from .state import get_context
+from .target import Cache, Defer, Retries
 
 __all__ = [
     # Version
@@ -30,8 +37,10 @@ __all__ = [
     # Classes
     "Execution",
     "ExecutionError",
+    "ExecutionTerminated",
     "ExecutionCancelled",
     "ExecutionTimeout",
+    "ExecutionAbandoned",
     "InputDismissed",
     "Input",
     "ModelSchema",

--- a/adapters/python/coflux/__init__.py
+++ b/adapters/python/coflux/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "group",
     "suspense",
     "suspend",
+    "select",
     "log_debug",
     "log_info",
     "log_warning",
@@ -85,6 +86,42 @@ def suspense(timeout: float | None = None):
             result = slow_task.submit().result()  # Will timeout after 30s
     """
     return get_context().suspense(timeout)
+
+
+def select(
+    handles: list[Execution | Input],
+    *,
+    cancel_remaining: bool = False,
+) -> tuple[Execution | Input, list[Execution | Input]]:
+    """Wait for the first of one or more handles (executions/inputs) to resolve.
+
+    Args:
+        handles: List of Execution and/or Input objects. Must be non-empty.
+        cancel_remaining: If True, cancel non-winner execution handles
+            atomically once a handle resolves. Input handles are left pending.
+
+    Returns:
+        Tuple of ``(winner, remaining)`` where ``winner`` is the first handle
+        to resolve (call ``.result()`` to get its value or raise its error),
+        and ``remaining`` is the list of handles that did not win, in input
+        order.
+
+    Example:
+        winner, remaining = cf.select([a.submit(), b.submit(), c.submit()])
+        value = winner.result()
+
+    Timeouts are taken from an enclosing ``cf.suspense(timeout=...)`` scope.
+    """
+    if not handles:
+        raise ValueError("select requires at least one handle")
+
+    winner_idx = get_context().select(handles, cancel_remaining=cancel_remaining)
+    if winner_idx is None:
+        raise ExecutionTimeout()
+
+    winner = handles[winner_idx]
+    remaining = [h for i, h in enumerate(handles) if i != winner_idx]
+    return winner, remaining
 
 
 def suspend(delay: float | dt.timedelta | dt.datetime | None = None) -> None:

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -9,17 +9,49 @@ import hashlib
 import json
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 from . import protocol
-from .errors import (
-    ExecutionCancelled,
-    ExecutionTimeout,
-    InputDismissed,
-    create_execution_error,
-)
-from .models import Asset, AssetEntry, AssetMetadata
+from .errors import ExecutionCancelled, InputDismissed, create_execution_error
+from .models import Asset, AssetEntry, AssetMetadata, Execution, Input
 from .serialization import deserialize_value, serialize_value
+
+
+def _handle_key(handle: Any) -> tuple[str, str]:
+    """Composite cache key for an Execution/Input handle."""
+    if isinstance(handle, Execution):
+        return ("execution", handle.id)
+    if isinstance(handle, Input):
+        return ("input", handle.id)
+    raise TypeError(f"Unsupported select handle type: {type(handle).__name__}")
+
+
+def _unwrap_response(
+    response: dict[str, Any],
+    parser: Callable[[Any], Any] | None = None,
+) -> Any:
+    """Convert a select winner response into a return value or raised error.
+
+    If ``parser`` is given, it is applied to the deserialized value before
+    returning. Error/cancelled/dismissed statuses raise regardless of
+    whether a parser is supplied.
+    """
+    status = response.get("status")
+    if status == "ok":
+        value = deserialize_value(response["value"])
+        return parser(value) if parser is not None else value
+    if status == "error":
+        error = response.get("error") or {}
+        raise create_execution_error(
+            error.get("type", ""),
+            error.get("message", ""),
+        )
+    if status == "cancelled":
+        raise ExecutionCancelled()
+    if status == "dismissed":
+        raise InputDismissed()
+    raise RuntimeError(f"Unexpected select status: {status}")
+
 
 # Context variable for group tracking
 _group_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
@@ -42,6 +74,11 @@ class ExecutorContext:
         self._defined_metrics: dict[str, dict] = {}
         self._defined_scales: dict[str, dict] = {}
         self._defined_groups: dict[str, dict] = {}
+        # Cache of resolved select responses keyed by (type, id). Populated
+        # by select() when a handle resolves; consumed by resolve_handle /
+        # poll_handle to avoid a round-trip for handles that have already
+        # been seen in this context's lifetime.
+        self._resolved: dict[tuple[str, str], dict[str, Any]] = {}
 
     def submit_execution(
         self,
@@ -86,66 +123,100 @@ class ExecutorContext:
         )
         return self._wait_response(request_id)
 
-    def resolve_execution(self, target_execution_id: str) -> Any:
-        """Resolve an execution by ID and deserialize the result."""
-        timeout = _timeout.get()
-        timeout_ms = int(timeout * 1000) if timeout is not None else None
-        request_id = protocol.request_resolve_reference(
-            self.execution_id,
-            target_execution_id,
-            timeout_ms=timeout_ms,
-        )
-        value = self._wait_response(request_id)
-        status = value.get("status")
-        if status == "error":
-            raise create_execution_error(
-                value.get("error_type", ""),
-                value.get("error_message", ""),
-            )
-        if status == "cancelled":
-            raise ExecutionCancelled()
-        if status == "timeout":
-            raise ExecutionTimeout()
-        if status == "suspended":
-            # The server has suspended this execution and will abort us.
-            # Block until the CLI kills this process.
-            while protocol.receive_message() is not None:
-                pass
-            raise SystemExit(0)
-        if status is not None:
-            raise RuntimeError(f"Unexpected resolve status: {status}")
-        return deserialize_value(value)
-
-    def poll_execution(
+    def select(
         self,
-        target_execution_id: str,
+        handles: list[Any],
+        *,
+        suspend: bool = True,
+        cancel_remaining: bool = False,
         timeout_ms: int | None = None,
-        default: Any = None,
-    ) -> Any:
-        """Poll for an execution result without suspending.
+    ) -> int | None:
+        """Wait for the first of one or more handles to resolve.
 
-        Returns the deserialized result if available, or `default` if not ready.
+        On success, the winner's response is stored in this context's
+        resolve cache so subsequent ``.result()`` / ``.poll()`` calls on the
+        handle can return without a round-trip.
+
+        Args:
+            handles: List of Execution or Input objects.
+            suspend: Whether to allow suspension while waiting.
+            cancel_remaining: If True, cancel non-winner execution handles.
+            timeout_ms: Optional wait timeout. If None, falls back to the
+                current ``cf.suspense`` timeout context var.
+
+        Returns:
+            The index in ``handles`` of the handle that resolved, or
+            ``None`` on timeout.
         """
-        request_id = protocol.request_resolve_reference(
+        if not handles:
+            raise ValueError("select requires at least one handle")
+
+        if timeout_ms is None:
+            timeout = _timeout.get()
+            if timeout is not None:
+                timeout_ms = int(timeout * 1000)
+
+        request_id = protocol.request_select(
             self.execution_id,
-            target_execution_id,
-            timeout_ms=timeout_ms or 0,
-            suspend=False,
+            [{"type": k, "id": i} for k, i in map(_handle_key, handles)],
+            timeout_ms=timeout_ms,
+            suspend=suspend,
+            cancel_remaining=cancel_remaining,
         )
-        value = self._wait_response(request_id)
-        if value is None:
-            return default
-        status = value.get("status")
-        if status == "error":
-            raise create_execution_error(
-                value.get("error_type", ""),
-                value.get("error_message", ""),
-            )
-        if status == "cancelled":
-            raise ExecutionCancelled()
-        if status is not None:
-            raise RuntimeError(f"Unexpected poll status: {status}")
-        return deserialize_value(value)
+        response = self._wait_response(request_id)
+        if response is None:
+            # Should not happen with the new protocol (timeouts send an
+            # explicit {"status": "timeout"} response). Treat as timeout for
+            # defensiveness.
+            return None
+
+        status = response.get("status")
+        if status == "timeout":
+            return None
+
+        winner = response.get("winner")
+        if winner is None:
+            raise RuntimeError(f"Unexpected select response: {response}")
+
+        self._resolved[_handle_key(handles[winner])] = response
+        return winner
+
+    def resolve_handle(self, handle: Any) -> Any:
+        """Block until ``handle`` resolves and return its value (or raise).
+
+        Uses this context's resolve cache if ``cf.select`` has already seen
+        the handle; otherwise issues a single-handle ``select`` call. If
+        the handle has a parser (e.g. an ``Input[Model]``), it is applied
+        to the deserialized value.
+        """
+        key = _handle_key(handle)
+        if key not in self._resolved:
+            if self.select([handle]) is None:
+                # A single-handle suspend=True call should always return a
+                # response (or the process is killed). None would indicate a
+                # timeout, which isn't possible here without a suspense scope;
+                # callers inside a suspense scope should use cf.select directly.
+                raise RuntimeError("Handle resolution timed out")
+        return _unwrap_response(self._resolved[key], handle._parser)
+
+    def poll_handle(
+        self,
+        handle: Any,
+        timeout: float | None,
+        default: Any,
+    ) -> Any:
+        """Non-suspending resolve: returns ``default`` if the handle isn't ready.
+
+        If the handle resolves, applies its parser (if any) to the value.
+        ``default`` is returned as-is when the handle isn't ready; no parser
+        is applied to it.
+        """
+        key = _handle_key(handle)
+        if key not in self._resolved:
+            timeout_ms = int(timeout * 1000) if timeout else 0
+            if self.select([handle], suspend=False, timeout_ms=timeout_ms) is None:
+                return default
+        return _unwrap_response(self._resolved[key], handle._parser)
 
     def get_asset_entries(self, asset_id: str) -> list[AssetEntry]:
         """Get all entries for an asset by ID."""
@@ -339,73 +410,6 @@ class ExecutorContext:
         )
         result = self._wait_response(request_id)
         return result["input_id"]
-
-    def resolve_input(self, input_external_id: str) -> Any:
-        """Resolve an input by external ID, blocking until a response is available.
-
-        Records a dependency and waits for the response. If no response is
-        available, the server suspends this execution.
-        """
-        timeout = _timeout.get()
-        timeout_ms = int(timeout * 1000) if timeout is not None else None
-        request_id = protocol.resolve_input(
-            input_external_id,
-            self.execution_id,
-            timeout_ms=timeout_ms,
-            suspend=True,
-        )
-        value = self._wait_response(request_id)
-        return self._handle_input_result(value)
-
-    def poll_input(
-        self,
-        input_external_id: str,
-        timeout_ms: int | None = None,
-        default: Any = None,
-    ) -> Any:
-        """Poll for an input response without suspending."""
-        request_id = protocol.resolve_input(
-            input_external_id,
-            self.execution_id,
-            timeout_ms=timeout_ms or 0,
-            suspend=False,
-        )
-        value = self._wait_response(request_id)
-        if value is None:
-            return default
-        status = value.get("status") if isinstance(value, dict) else None
-        if status == "error":
-            raise create_execution_error(
-                value.get("error_type", ""),
-                value.get("error_message", ""),
-            )
-        if status == "dismissed":
-            raise InputDismissed()
-        if status is not None:
-            raise RuntimeError(f"Unexpected poll status: {status}")
-        return deserialize_value(value)
-
-    def _handle_input_result(self, value: Any) -> Any:
-        """Handle the response from a resolve_input RPC."""
-        if value is None:
-            return None
-        status = value.get("status") if isinstance(value, dict) else None
-        if status == "error":
-            raise create_execution_error(
-                value.get("error_type", ""),
-                value.get("error_message", ""),
-            )
-        if status == "dismissed":
-            raise InputDismissed()
-        if status == "timeout":
-            raise ExecutionTimeout()
-        if status == "suspended":
-            while protocol.receive_message() is not None:
-                pass
-            raise SystemExit(0)
-        if status is not None:
-            raise RuntimeError(f"Unexpected input status: {status}")
-        return deserialize_value(value)
 
     def log(self, level: int, message: str) -> None:
         """Send a simple log message (used for stdout/stderr capture).

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Iterator
 
 from . import protocol
 from .errors import (
+    ExecutionAbandoned,
     ExecutionCancelled,
     ExecutionTimeout,
     InputDismissed,
@@ -57,6 +58,8 @@ def _unwrap_response(
         raise InputDismissed()
     if status == "timeout":
         raise ExecutionTimeout()
+    if status == "abandoned":
+        raise ExecutionAbandoned()
     raise RuntimeError(f"Unexpected select status: {status}")
 
 

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 
 from . import protocol
-from .errors import ExecutionCancelled, InputDismissed, create_execution_error
+from .errors import (
+    ExecutionCancelled,
+    ExecutionTimeout,
+    InputDismissed,
+    create_execution_error,
+)
 from .models import Asset, AssetEntry, AssetMetadata, Execution, Input
 from .serialization import deserialize_value, serialize_value
 
@@ -50,6 +55,8 @@ def _unwrap_response(
         raise ExecutionCancelled()
     if status == "dismissed":
         raise InputDismissed()
+    if status == "timeout":
+        raise ExecutionTimeout()
     raise RuntimeError(f"Unexpected select status: {status}")
 
 
@@ -165,13 +172,8 @@ class ExecutorContext:
         )
         response = self._wait_response(request_id)
         if response is None:
-            # Should not happen with the new protocol (timeouts send an
-            # explicit {"status": "timeout"} response). Treat as timeout for
-            # defensiveness.
-            return None
-
-        status = response.get("status")
-        if status == "timeout":
+            # Server signals a wait timeout (nothing resolved before the
+            # timeout expired) by returning a null result.
             return None
 
         winner = response.get("winner")
@@ -192,11 +194,10 @@ class ExecutorContext:
         key = _handle_key(handle)
         if key not in self._resolved:
             if self.select([handle]) is None:
-                # A single-handle suspend=True call should always return a
-                # response (or the process is killed). None would indicate a
-                # timeout, which isn't possible here without a suspense scope;
-                # callers inside a suspense scope should use cf.select directly.
-                raise RuntimeError("Handle resolution timed out")
+                # The wait expired before the handle resolved. Only reachable
+                # from inside a `cf.suspense(timeout=...)` scope; otherwise the
+                # server either resolves or kills the process.
+                raise TimeoutError("timed out waiting for handle to resolve")
         return _unwrap_response(self._resolved[key], handle._parser)
 
     def poll_handle(

--- a/adapters/python/coflux/context.py
+++ b/adapters/python/coflux/context.py
@@ -361,11 +361,21 @@ class ExecutorContext:
         )
         return Asset(asset_id, metadata)
 
-    def cancel_execution(self, target_execution_id: str) -> None:
-        """Cancel another execution."""
-        request_id = protocol.request_cancel_execution(
+    def cancel(self, handles: list[Any]) -> None:
+        """Cancel one or more handles (executions and/or inputs).
+
+        For each execution handle, its result is recorded as ``cancelled``
+        and descendant executions are cancelled recursively. For each
+        input handle, it transitions to a terminal ``cancelled`` state
+        (distinct from ``dismissed``) and any select waiters are notified.
+
+        Handles that are already resolved are silently skipped.
+        """
+        if not handles:
+            return
+        request_id = protocol.request_cancel(
             self.execution_id,
-            target_execution_id,
+            [{"type": k, "id": i} for k, i in map(_handle_key, handles)],
         )
         self._wait_response(request_id)
 

--- a/adapters/python/coflux/decorators.py
+++ b/adapters/python/coflux/decorators.py
@@ -11,6 +11,24 @@ P = t.ParamSpec("P")
 T = t.TypeVar("T")
 
 
+class _TargetDecorator(t.Protocol):
+    """Decorator protocol that unwraps ``Coroutine`` for async functions.
+
+    Overloading on ``__call__`` (rather than on the factory function)
+    lets the type checker pick the right overload based on the decorated
+    function's return type — which is visible at application time, but
+    not at the factory call.
+    """
+
+    @t.overload
+    def __call__(
+        self, fn: t.Callable[P, t.Coroutine[t.Any, t.Any, T]]
+    ) -> Target[P, T]: ...
+
+    @t.overload
+    def __call__(self, fn: t.Callable[P, T]) -> Target[P, T]: ...
+
+
 def task(
     *,
     name: str | None = None,
@@ -23,10 +41,15 @@ def task(
     memo: bool | t.Iterable[str] = False,
     requires: dict[str, str | bool | list[str]] | None = None,
     timeout: float | dt.timedelta = 0,
-) -> t.Callable[[t.Callable[P, T]], Target[P, T]]:
-    """Decorator for defining a task."""
+) -> _TargetDecorator:
+    """Decorator for defining a task.
 
-    def decorator(fn: t.Callable[P, T]) -> Target[P, T]:
+    For ``async def`` functions, the coroutine is run to completion by
+    the executor; the task's return type is the coroutine's resolved
+    value (not the coroutine itself).
+    """
+
+    def decorator(fn):
         return Target(
             fn,
             "task",
@@ -42,7 +65,7 @@ def task(
             timeout=timeout,
         )
 
-    return decorator
+    return decorator  # type: ignore[return-value]
 
 
 def workflow(
@@ -57,10 +80,15 @@ def workflow(
     memo: bool = False,
     requires: dict[str, str | bool | list[str]] | None = None,
     timeout: float | dt.timedelta = 0,
-) -> t.Callable[[t.Callable[P, T]], Target[P, T]]:
-    """Decorator for defining a workflow."""
+) -> _TargetDecorator:
+    """Decorator for defining a workflow.
 
-    def decorator(fn: t.Callable[P, T]) -> Target[P, T]:
+    For ``async def`` functions, the coroutine is run to completion by
+    the executor; the workflow's return type is the coroutine's resolved
+    value (not the coroutine itself).
+    """
+
+    def decorator(fn):
         return Target(
             fn,
             "workflow",
@@ -76,7 +104,7 @@ def workflow(
             timeout=timeout,
         )
 
-    return decorator
+    return decorator  # type: ignore[return-value]
 
 
 def stub(
@@ -91,10 +119,10 @@ def stub(
     defer: bool | Defer = False,
     delay: float | dt.timedelta = 0,
     memo: bool | t.Iterable[str] = False,
-) -> t.Callable[[t.Callable[P, T]], Target[P, T]]:
+) -> _TargetDecorator:
     """Decorator for defining a stub (external reference)."""
 
-    def decorator(fn: t.Callable[P, T]) -> Target[P, T]:
+    def decorator(fn):
         return Target(
             fn,
             type,
@@ -110,4 +138,4 @@ def stub(
             is_stub=True,
         )
 
-    return decorator
+    return decorator  # type: ignore[return-value]

--- a/adapters/python/coflux/errors.py
+++ b/adapters/python/coflux/errors.py
@@ -22,17 +22,46 @@ class ExecutionError(Exception):
         super().__init__(message)
 
 
-class ExecutionCancelled(Exception):
+class ExecutionTerminated(Exception):
+    """Base class for orchestration-initiated terminations.
+
+    Distinct from ExecutionError, which wraps a user exception raised by
+    the dependency's own code. Subclasses here represent reasons the
+    server decided the dependency would not complete normally (cancelled,
+    timed out, abandoned, crashed).
+
+    Catch ExecutionTerminated to handle any of these uniformly::
+
+        except ExecutionTerminated:
+            # any server-initiated termination
+            ...
+
+    Or catch specific subclasses to distinguish causes.
+    """
+
+
+class ExecutionCancelled(ExecutionTerminated):
     """Raised when a child execution was cancelled."""
 
     def __init__(self, message: str = "execution was cancelled"):
         super().__init__(message)
 
 
-class ExecutionTimeout(Exception):
+class ExecutionTimeout(ExecutionTerminated):
     """Raised when a child execution timed out."""
 
     def __init__(self, message: str = "execution timed out"):
+        super().__init__(message)
+
+
+class ExecutionAbandoned(ExecutionTerminated):
+    """Raised when a child execution was abandoned.
+
+    The server gave up on the execution — typically because the worker
+    session expired (heartbeat missed) or the session was removed.
+    """
+
+    def __init__(self, message: str = "execution was abandoned"):
         super().__init__(message)
 
 

--- a/adapters/python/coflux/executor.py
+++ b/adapters/python/coflux/executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import inspect
 import os
@@ -98,7 +99,13 @@ def execute_target(
         )
 
         with capture_output(execution_id):
-            result = fn(*deserialized_args)
+            if inspect.iscoroutinefunction(fn):
+                # Native async def targets: run the coroutine to completion.
+                # Each execution is its own OS process with nothing else
+                # scheduled, so a fresh event loop per call is fine.
+                result = asyncio.run(fn(*deserialized_args))
+            else:
+                result = fn(*deserialized_args)
 
         # Serialize and send result
         result_value = serialize_value(result)

--- a/adapters/python/coflux/models.py
+++ b/adapters/python/coflux/models.py
@@ -148,6 +148,16 @@ class _Handle(t.Generic[T]):
         """Return the resolved value if ready, else ``default``."""
         return get_context().poll_handle(self, timeout, default)
 
+    def cancel(self) -> None:
+        """Cancel this handle.
+
+        For an ``Execution``, records its result as ``cancelled`` and
+        recursively cancels descendants. For an ``Input``, transitions it
+        to a terminal ``cancelled`` state (distinct from ``dismissed``).
+        No-op if the handle is already resolved.
+        """
+        get_context().cancel([self])
+
 
 class Input(_Handle[T]):
     """A handle to a requested input, identified by its external ID.
@@ -198,7 +208,3 @@ class Execution(_Handle[T]):
     @property
     def target(self) -> str:
         return self._target
-
-    def cancel(self) -> None:
-        """Cancel this execution."""
-        get_context().cancel_execution(self._execution_id)

--- a/adapters/python/coflux/models.py
+++ b/adapters/python/coflux/models.py
@@ -6,13 +6,12 @@ import fnmatch
 import functools
 import typing as t
 from pathlib import Path
+
 from .state import get_context
 
 
 T = t.TypeVar("T")
 D = t.TypeVar("D")
-
-_MISSING = object()
 
 
 class ModelSchema(t.Protocol):
@@ -119,44 +118,25 @@ class Asset:
         return {e.path: e.restore(at=at) for e in entries}
 
 
-class Input(t.Generic[T]):
-    """A handle to a requested input, identified by its external ID.
+class _Handle(t.Generic[T]):
+    """Base for handles that resolve via ``cf.select``.
 
-    Can be passed between executions (only the ID is needed).
+    Resolved responses are cached on the ``ExecutorContext`` (keyed by
+    handle type + id), not on the handle itself — handles stay pure
+    reference objects so they're safe to serialize and pass between
+    executions.
 
-    When parameterised with a model class (e.g. ``Input[MyModel]``), the
-    type argument is preserved at runtime so that ``result()`` and ``poll()``
-    can automatically validate the response using ``model_validate``.
+    Subclasses may set ``_parser`` (typically via ``__class_getitem__``)
+    to transform resolved values into typed objects (e.g. a Pydantic
+    model instance). When unset, ``.result()`` / ``.poll()`` return the
+    raw value. The parser is applied inside the context's resolve path.
     """
 
-    _type_arg: type | None = None
-
-    def __class_getitem__(cls, item: type) -> type:
-        # Create a subclass that remembers the type argument at runtime.
-        # This means Input[MyModel](id).result() can call MyModel.model_validate().
-        name = getattr(item, "__name__", str(item))
-        return type(f"Input[{name}]", (cls,), {"_type_arg": item})
-
-    def __init__(self, input_id: str):
-        self._input_id = input_id
-
-    @property
-    def id(self) -> str:
-        return self._input_id
+    _parser: t.ClassVar[t.Callable[[t.Any], t.Any] | None] = None
 
     def result(self) -> T:
-        """Wait for and return the input response.
-
-        Records a dependency and blocks until the response is available,
-        suspending the execution if necessary. If this Input was
-        parameterised with a model class, the response is validated
-        and returned as an instance of that model.
-        """
-        ctx = get_context()
-        value = ctx.resolve_input(self._input_id)
-        if self._type_arg is not None and hasattr(self._type_arg, "model_validate"):
-            return self._type_arg.model_validate(value)
-        return value
+        """Wait for and return the resolved value (or raise on error)."""
+        return get_context().resolve_handle(self)
 
     @t.overload
     def poll(self, timeout: float | None = None) -> T | None: ...
@@ -165,25 +145,41 @@ class Input(t.Generic[T]):
     def poll(self, timeout: float | None = None, *, default: D) -> T | D: ...
 
     def poll(self, timeout: float | None = None, default: t.Any = None) -> t.Any:
-        """Poll for the input response without suspending.
-
-        Returns the response if available, or ``default`` if not ready yet.
-        """
-        ctx = get_context()
-        timeout_ms = int(timeout * 1000) if timeout else None
-        value = ctx.poll_input(
-            self._input_id,
-            timeout_ms,
-            default=_MISSING,
-        )
-        if value is _MISSING:
-            return default
-        if self._type_arg is not None and hasattr(self._type_arg, "model_validate"):
-            return self._type_arg.model_validate(value)
-        return value
+        """Return the resolved value if ready, else ``default``."""
+        return get_context().poll_handle(self, timeout, default)
 
 
-class Execution(t.Generic[T]):
+class Input(_Handle[T]):
+    """A handle to a requested input, identified by its external ID.
+
+    Can be passed between executions (only the ID is needed).
+
+    When parameterised with a model class (e.g. ``Input[MyModel]``), the
+    model's ``model_validate`` is captured as the handle's parser so that
+    ``result()`` / ``poll()`` return an instance of the model.
+    """
+
+    _type_arg: type | None = None
+
+    def __class_getitem__(cls, item: type) -> type:
+        # Create a subclass that remembers the type argument and (if the
+        # type exposes ``model_validate``) captures it as the parser.
+        name = getattr(item, "__name__", str(item))
+        attrs: dict[str, t.Any] = {"_type_arg": item}
+        parser = getattr(item, "model_validate", None)
+        if parser is not None:
+            attrs["_parser"] = parser
+        return type(f"Input[{name}]", (cls,), attrs)
+
+    def __init__(self, input_id: str):
+        self._input_id = input_id
+
+    @property
+    def id(self) -> str:
+        return self._input_id
+
+
+class Execution(_Handle[T]):
     """A handle to a submitted execution that can be awaited for its result."""
 
     def __init__(self, execution_id: str, module: str, target: str):
@@ -203,27 +199,6 @@ class Execution(t.Generic[T]):
     def target(self) -> str:
         return self._target
 
-    def result(self) -> T:
-        """Wait for and return the execution result."""
-        ctx = get_context()
-        return ctx.resolve_execution(self._execution_id)
-
-    @t.overload
-    def poll(self, timeout: float | None = None) -> T | None: ...
-
-    @t.overload
-    def poll(self, timeout: float | None = None, *, default: D) -> T | D: ...
-
-    def poll(self, timeout: float | None = None, default: t.Any = None) -> t.Any:
-        """Poll for the execution result without suspending.
-
-        Returns the result if available, or ``default`` if not ready yet.
-        """
-        ctx = get_context()
-        timeout_ms = int(timeout * 1000) if timeout else None
-        return ctx.poll_execution(self._execution_id, timeout_ms, default=default)
-
     def cancel(self) -> None:
         """Cancel this execution."""
-        ctx = get_context()
-        ctx.cancel_execution(self._execution_id)
+        get_context().cancel_execution(self._execution_id)

--- a/adapters/python/coflux/protocol.py
+++ b/adapters/python/coflux/protocol.py
@@ -217,21 +217,33 @@ def request_submit_execution(
     return get_protocol().send_request("submit_execution", params)
 
 
-def request_resolve_reference(
+def request_select(
     execution_id: str,
-    target_execution_id: str,
+    handles: list[dict[str, str]],
     timeout_ms: int | None = None,
     suspend: bool = True,
+    cancel_remaining: bool = False,
 ) -> int:
-    """Request to resolve a reference (get result of another execution)."""
+    """Request to wait for the first of one or more handles to resolve.
+
+    Args:
+        execution_id: The calling execution.
+        handles: List of handle dicts: ``{"type": "execution"|"input", "id": "..."}``.
+        timeout_ms: Maximum wait time in ms. None means no timeout.
+        suspend: If True, the server may suspend the caller while waiting.
+        cancel_remaining: If True, cancel non-winner execution handles atomically
+            once a handle resolves.
+    """
     params: dict[str, Any] = {
         "execution_id": execution_id,
-        "target_execution_id": target_execution_id,
+        "handles": handles,
+        "suspend": suspend,
     }
     if timeout_ms is not None:
         params["timeout_ms"] = timeout_ms
-    params["suspend"] = suspend
-    return get_protocol().send_request("resolve_reference", params)
+    if cancel_remaining:
+        params["cancel_remaining"] = cancel_remaining
+    return get_protocol().send_request("select", params)
 
 
 def request_persist_asset(
@@ -364,30 +376,6 @@ def submit_input(
     if requires is not None:
         params["requires"] = requires
     return get_protocol().send_request("submit_input", params)
-
-
-def resolve_input(
-    input_external_id: str,
-    from_execution_id: str,
-    timeout_ms: int | None = None,
-    suspend: bool = True,
-) -> int:
-    """Resolve an input by external ID, waiting for its response.
-
-    Args:
-        input_external_id: The input to resolve.
-        from_execution_id: The execution waiting for the response.
-        timeout_ms: Poll timeout in milliseconds.
-        suspend: Whether to suspend if response not available.
-    """
-    params: dict[str, Any] = {
-        "input_external_id": input_external_id,
-        "from_execution_id": from_execution_id,
-    }
-    if timeout_ms is not None:
-        params["timeout_ms"] = timeout_ms
-    params["suspend"] = suspend
-    return get_protocol().send_request("resolve_input", params)
 
 
 def request_cancel_execution(

--- a/adapters/python/coflux/protocol.py
+++ b/adapters/python/coflux/protocol.py
@@ -378,16 +378,16 @@ def submit_input(
     return get_protocol().send_request("submit_input", params)
 
 
-def request_cancel_execution(
+def request_cancel(
     execution_id: str,
-    target_execution_id: str,
+    handles: list[dict[str, str]],
 ) -> int:
-    """Request to cancel another execution."""
+    """Request to cancel one or more handles (executions and/or inputs)."""
     return get_protocol().send_request(
-        "cancel_execution",
+        "cancel",
         {
             "execution_id": execution_id,
-            "target_execution_id": target_execution_id,
+            "handles": handles,
         },
     )
 

--- a/adapters/python/coflux/target.py
+++ b/adapters/python/coflux/target.py
@@ -280,7 +280,28 @@ def serialize_retries(retries: Retries) -> dict:
 
 
 class Target(t.Generic[P, T]):
-    """Wrapper for a decorated task or workflow function."""
+    """Wrapper for a decorated task or workflow function.
+
+    The fluent ``with_*`` methods return a new ``Target`` with per-call-site
+    overrides applied, leaving the original decorator-bound target unchanged.
+    Only the original is registered during discovery; fluent copies are
+    call-site wrappers.
+
+    Examples:
+        # Override a single option at the call site
+        my_task.with_retries(3).submit(x)
+
+        # Disable a decorator-level option
+        my_task.with_cache(False).submit(x)
+
+        # Stash a preconfigured variant and reuse it
+        cached = my_task.with_cache(60)
+        cached.submit(a)
+        cached.submit(b)
+
+        # Chain multiple overrides
+        my_task.with_cache(60).with_timeout(30).submit(x)
+    """
 
     def __init__(
         self,
@@ -318,6 +339,52 @@ class Target(t.Generic[P, T]):
             is_stub,
         )
         functools.update_wrapper(self, fn)
+
+    def _copy(self, **definition_overrides: t.Any) -> Target[P, T]:
+        """Return a new Target with ``_definition`` fields overridden."""
+        new = Target.__new__(type(self))
+        new._fn = self._fn
+        new._name = self._name
+        new._module = self._module
+        new._definition = self._definition._replace(**definition_overrides)
+        functools.update_wrapper(new, self._fn)
+        return new
+
+    def with_cache(self, cache: bool | float | dt.timedelta | Cache) -> Target[P, T]:
+        """Return a new Target with caching config overridden for this call site.
+
+        Pass ``False`` to disable caching that was set on the decorator.
+        """
+        return self._copy(cache=_expand_cache(cache))
+
+    def with_retries(self, retries: int | bool | Retries) -> Target[P, T]:
+        """Return a new Target with retries config overridden for this call site.
+
+        Pass ``0`` or ``False`` to disable retries.
+        """
+        return self._copy(retries=_expand_retries(retries))
+
+    def with_defer(self, defer: bool | Defer) -> Target[P, T]:
+        """Return a new Target with defer config overridden for this call site."""
+        return self._copy(defer=_expand_defer(defer))
+
+    def with_memo(self, memo: bool | t.Iterable[str] | str) -> Target[P, T]:
+        """Return a new Target with memoisation config overridden for this call site."""
+        return self._copy(memo=_parse_memo(memo, self._definition.parameters))
+
+    def with_delay(self, delay: float | dt.timedelta) -> Target[P, T]:
+        """Return a new Target with submission delay overridden for this call site."""
+        return self._copy(delay=delay)
+
+    def with_timeout(self, timeout: float | dt.timedelta) -> Target[P, T]:
+        """Return a new Target with execution timeout overridden for this call site."""
+        return self._copy(timeout=timeout)
+
+    def with_requires(
+        self, requires: dict[str, str | bool | list[str]] | None
+    ) -> Target[P, T]:
+        """Return a new Target with routing tags overridden for this call site."""
+        return self._copy(requires=_parse_requires(requires))
 
     @property
     def name(self) -> str:

--- a/cli/internal/adapter/protocol.go
+++ b/cli/internal/adapter/protocol.go
@@ -238,10 +238,10 @@ type SuspendParams struct {
 	ExecuteAfter *int64 `json:"execute_after,omitempty"` // timestamp in ms
 }
 
-// CancelExecutionParams for cancel_execution request
-type CancelExecutionParams struct {
-	ExecutionID       string `json:"execution_id"`
-	TargetExecutionID string `json:"target_execution_id"`
+// CancelParams for cancel request
+type CancelParams struct {
+	ExecutionID string         `json:"execution_id"`
+	Handles     []SelectHandle `json:"handles"`
 }
 
 // RegisterGroupParams for register_group notification

--- a/cli/internal/adapter/protocol.go
+++ b/cli/internal/adapter/protocol.go
@@ -86,14 +86,20 @@ type ErrorInfo struct {
 	Message string `json:"message"`
 }
 
-// ResolveResult represents the outcome of resolving a reference.
-// A nil ResolveResult (with nil error) means no result is available yet (poll timeout).
-// Status is one of "value", "error", "cancelled", "timeout", or "suspended".
-type ResolveResult struct {
-	Status       string
-	Value        *Value // set when Status == "value"
-	ErrorType    string // set when Status == "error"
-	ErrorMessage string // set when Status == "error"
+// SelectResult represents the outcome of a select call.
+// Status is one of "ok", "error", "cancelled", "dismissed", or "timeout".
+// Winner is set for all statuses except "timeout".
+type SelectResult struct {
+	Winner *int         // index into handles; nil when Status == "timeout"
+	Status string       // "ok" | "error" | "cancelled" | "dismissed" | "timeout"
+	Value  *Value       // set when Status == "ok"
+	Error  *ErrorDetail // set when Status == "error"
+}
+
+// SelectHandle identifies a single handle in a select call.
+type SelectHandle struct {
+	Type string `json:"type"` // "execution" or "input"
+	ID   string `json:"id"`
 }
 
 // ReadyMessage is sent by executor when it's ready for work
@@ -193,12 +199,13 @@ type SubmitExecutionResult struct {
 	Reference []any `json:"reference"`
 }
 
-// ResolveReferenceParams for resolve_reference request
-type ResolveReferenceParams struct {
-	ExecutionID       string `json:"execution_id"`
-	TargetExecutionID string `json:"target_execution_id"`
-	TimeoutMs         *int64 `json:"timeout_ms,omitempty"`
-	Suspend           *bool  `json:"suspend,omitempty"`
+// SelectParams for select request
+type SelectParams struct {
+	ExecutionID     string         `json:"execution_id"`
+	Handles         []SelectHandle `json:"handles"`
+	TimeoutMs       *int64         `json:"timeout_ms,omitempty"`
+	Suspend         bool           `json:"suspend"`
+	CancelRemaining bool           `json:"cancel_remaining,omitempty"`
 }
 
 // PersistAssetParams for persist_asset request
@@ -268,14 +275,6 @@ type SubmitInputParams struct {
 	Actions      []string            `json:"actions,omitempty"` // [respond_label, dismiss_label]
 	Initial      any                 `json:"initial,omitempty"` // Plain JSON initial values
 	Requires     map[string][]string `json:"requires,omitempty"`
-}
-
-// ResolveInputParams for resolve_input request
-type ResolveInputParams struct {
-	InputExternalID string `json:"input_external_id"`
-	FromExecutionID string `json:"from_execution_id"`
-	TimeoutMs       *int64 `json:"timeout_ms,omitempty"`
-	Suspend         *bool  `json:"suspend,omitempty"`
 }
 
 // ParseMessage parses a JSON message from the executor

--- a/cli/internal/adapter/protocol.go
+++ b/cli/internal/adapter/protocol.go
@@ -86,11 +86,13 @@ type ErrorInfo struct {
 	Message string `json:"message"`
 }
 
-// SelectResult represents the outcome of a select call.
-// Status is one of "ok", "error", "cancelled", "dismissed", or "timeout".
-// Winner is set for all statuses except "timeout".
+// SelectResult represents the outcome of a select call where a handle
+// resolved. A nil *SelectResult means the select wait itself expired
+// without any handle resolving.
+// Status is one of "ok", "error", "cancelled", "dismissed", or "timeout"
+// (the last meaning the resolved handle's execution timed out).
 type SelectResult struct {
-	Winner *int         // index into handles; nil when Status == "timeout"
+	Winner *int         // index into handles
 	Status string       // "ok" | "error" | "cancelled" | "dismissed" | "timeout"
 	Value  *Value       // set when Status == "ok"
 	Error  *ErrorDetail // set when Status == "error"

--- a/cli/internal/pool/pool.go
+++ b/cli/internal/pool/pool.go
@@ -28,8 +28,8 @@ type ExecutionHandler interface {
 	UploadBlob(ctx context.Context, executionID, sourcePath string) (string, error)
 	// Suspend suspends an execution
 	Suspend(ctx context.Context, executionID string, executeAfter *int64) error
-	// CancelExecution cancels another execution
-	CancelExecution(ctx context.Context, executionID string, targetExecutionID string) error
+	// Cancel cancels one or more handles (executions and/or inputs)
+	Cancel(ctx context.Context, executionID string, handles []adapter.SelectHandle) error
 	// RegisterGroup registers a group for organizing child executions
 	RegisterGroup(ctx context.Context, executionID string, groupID int, name *string) error
 	// RecordLog records a log message (level: 0=debug, 1=stdout, 2=info, 3=stderr, 4=warning, 5=error)
@@ -258,7 +258,7 @@ loop:
 		case "metric":
 			p.handleMetric(execCtx, executionID, params, logger)
 
-		case "submit_execution", "select", "persist_asset", "get_asset", "suspend", "cancel_execution", "download_blob", "upload_blob", "submit_input":
+		case "submit_execution", "select", "persist_asset", "get_asset", "suspend", "cancel", "download_blob", "upload_blob", "submit_input":
 			p.handleRequest(execCtx, exec, method, *id, params, logger)
 
 		case "register_group":
@@ -539,13 +539,13 @@ func (p *Pool) handleRequest(ctx context.Context, exec *adapter.Executor, method
 			result = map[string]any{}
 		}
 
-	case "cancel_execution":
-		var req adapter.CancelExecutionParams
+	case "cancel":
+		var req adapter.CancelParams
 		if err := json.Unmarshal(params, &req); err != nil {
 			errInfo = &adapter.ErrorInfo{Code: "parse_error", Message: err.Error()}
 			break
 		}
-		if err := p.handler.CancelExecution(ctx, req.ExecutionID, req.TargetExecutionID); err != nil {
+		if err := p.handler.Cancel(ctx, req.ExecutionID, req.Handles); err != nil {
 			errInfo = &adapter.ErrorInfo{Code: "cancel_error", Message: err.Error()}
 		} else {
 			result = map[string]any{}

--- a/cli/internal/pool/pool.go
+++ b/cli/internal/pool/pool.go
@@ -16,8 +16,8 @@ import (
 type ExecutionHandler interface {
 	// SubmitExecution submits a child execution
 	SubmitExecution(ctx context.Context, params *adapter.SubmitExecutionParams) (map[string]any, error)
-	// ResolveReference resolves a reference to get its result
-	ResolveReference(ctx context.Context, executionID string, targetExecutionID string, timeoutMs *int64, suspend *bool) (*adapter.ResolveResult, error)
+	// Select waits for the first of one or more handles (executions/inputs) to resolve
+	Select(ctx context.Context, params *adapter.SelectParams) (*adapter.SelectResult, error)
 	// PersistAsset persists files as an asset
 	PersistAsset(ctx context.Context, executionID string, paths []string, metadata map[string]any, preResolved map[string][]any) (map[string]any, error)
 	// GetAsset retrieves asset entries
@@ -47,8 +47,6 @@ type ExecutionHandler interface {
 	ReportTimeout(ctx context.Context, executionID string) error
 	// SubmitInput creates an input request and returns its external ID
 	SubmitInput(ctx context.Context, params *adapter.SubmitInputParams) (string, error)
-	// ResolveInput waits for an input response by external ID
-	ResolveInput(ctx context.Context, params *adapter.ResolveInputParams) (*adapter.ResolveResult, error)
 	// NotifyTerminated notifies the server that an execution's process has exited
 	NotifyTerminated(ctx context.Context, executionID string) error
 }
@@ -260,7 +258,7 @@ loop:
 		case "metric":
 			p.handleMetric(execCtx, executionID, params, logger)
 
-		case "submit_execution", "resolve_reference", "persist_asset", "get_asset", "suspend", "cancel_execution", "download_blob", "upload_blob", "submit_input", "resolve_input":
+		case "submit_execution", "select", "persist_asset", "get_asset", "suspend", "cancel_execution", "download_blob", "upload_blob", "submit_input":
 			p.handleRequest(execCtx, exec, method, *id, params, logger)
 
 		case "register_group":
@@ -455,34 +453,27 @@ func (p *Pool) handleRequest(ctx context.Context, exec *adapter.Executor, method
 			result = submitResult
 		}
 
-	case "resolve_reference":
-		var req adapter.ResolveReferenceParams
+	case "select":
+		var req adapter.SelectParams
 		if err := json.Unmarshal(params, &req); err != nil {
 			errInfo = &adapter.ErrorInfo{Code: "parse_error", Message: err.Error()}
 			break
 		}
-		resolved, err := p.handler.ResolveReference(ctx, req.ExecutionID, req.TargetExecutionID, req.TimeoutMs, req.Suspend)
+		resolved, err := p.handler.Select(ctx, &req)
 		if err != nil {
-			errInfo = &adapter.ErrorInfo{Code: "resolve_error", Message: err.Error()}
-		} else if resolved == nil {
-			// No result available (poll timeout) — result stays nil, sent as JSON null
-		} else {
-			switch resolved.Status {
-			case "value":
-				result = resolved.Value
-			case "error":
-				result = map[string]any{
-					"status":        "error",
-					"error_type":    resolved.ErrorType,
-					"error_message": resolved.ErrorMessage,
-				}
-			case "cancelled":
-				result = map[string]any{"status": "cancelled"}
-			case "timeout":
-				result = map[string]any{"status": "timeout"}
-			case "suspended":
-				result = map[string]any{"status": "suspended"}
+			errInfo = &adapter.ErrorInfo{Code: "select_error", Message: err.Error()}
+		} else if resolved != nil {
+			out := map[string]any{"status": resolved.Status}
+			if resolved.Winner != nil {
+				out["winner"] = *resolved.Winner
 			}
+			if resolved.Value != nil {
+				out["value"] = resolved.Value
+			}
+			if resolved.Error != nil {
+				out["error"] = resolved.Error
+			}
+			result = out
 		}
 
 	case "persist_asset":
@@ -573,33 +564,6 @@ func (p *Pool) handleRequest(ctx context.Context, exec *adapter.Executor, method
 			result = map[string]any{"input_id": inputID}
 		}
 
-	case "resolve_input":
-		var req adapter.ResolveInputParams
-		if err := json.Unmarshal(params, &req); err != nil {
-			errInfo = &adapter.ErrorInfo{Code: "parse_error", Message: err.Error()}
-			break
-		}
-		resolved, err := p.handler.ResolveInput(ctx, &req)
-		if err != nil {
-			errInfo = &adapter.ErrorInfo{Code: "input_error", Message: err.Error()}
-		} else if resolved == nil {
-			// No result available (poll timeout)
-		} else {
-			switch resolved.Status {
-			case "value":
-				result = resolved.Value
-			case "error":
-				result = map[string]any{
-					"status":        "error",
-					"error_type":    resolved.ErrorType,
-					"error_message": resolved.ErrorMessage,
-				}
-			case "cancelled", "dismissed":
-				result = map[string]any{"status": "dismissed"}
-			case "suspended":
-				result = map[string]any{"status": "suspended"}
-			}
-		}
 	}
 
 	// If the context was cancelled (e.g., execution timed out), don't

--- a/cli/internal/worker/worker.go
+++ b/cli/internal/worker/worker.go
@@ -845,17 +845,23 @@ func (w *Worker) processReferences(refs [][]any) ([]any, error) {
 	return result, nil
 }
 
-func (w *Worker) ResolveReference(ctx context.Context, executionID string, targetExecutionID string, timeoutMs *int64, suspend *bool) (*adapter.ResolveResult, error) {
+func (w *Worker) Select(ctx context.Context, params *adapter.SelectParams) (*adapter.SelectResult, error) {
 	var result any
 	for {
 		conn, err := w.waitForConn(ctx)
 		if err != nil {
 			return nil, err
 		}
-		result, err = conn.Request(ctx, "get_result", targetExecutionID, executionID, timeoutMs, suspend)
+		result, err = conn.Request(ctx, "select",
+			params.Handles,
+			params.ExecutionID,
+			params.TimeoutMs,
+			params.Suspend,
+			params.CancelRemaining,
+		)
 		if err != nil {
 			if isConnectionError(err) {
-				w.logger.Debug("retrying get_result after reconnect", "execution", targetExecutionID)
+				w.logger.Debug("retrying select after reconnect")
 				continue
 			}
 			return nil, err
@@ -863,85 +869,76 @@ func (w *Worker) ResolveReference(ctx context.Context, executionID string, targe
 		break
 	}
 
-	// nil result means the wait expired with no result available (poll timeout)
 	if result == nil {
 		return nil, nil
 	}
 
-	// Result is ["value", value_tuple] or ["error", ...] or ["cancelled"] or ["suspended"]
-	if arr, ok := result.([]any); ok && len(arr) >= 1 {
-		resultType := getString(arr[0])
-		switch resultType {
-		case "value":
-			if len(arr) < 2 {
-				return nil, fmt.Errorf("value result missing value tuple: %v", arr)
-			}
-			valueArr, ok := arr[1].([]any)
-			if !ok {
-				return nil, fmt.Errorf("value tuple is not an array: %T", arr[1])
-			}
-			value, err := api.ParseValue(valueArr)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse value: %w", err)
-			}
-			adapterRefs, err := w.refsToAdapter(value.References)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert references: %w", err)
-			}
-			// Convert to adapter value
-			switch value.Type {
-			case api.ValueTypeRaw:
-				return &adapter.ResolveResult{
-					Status: "value",
-					Value: &adapter.Value{
-						Type:       "inline",
-						Format:     "json",
-						Value:      value.Content,
-						References: adapterRefs,
-					},
-				}, nil
-			case api.ValueTypeBlob:
-				path, err := w.blobs.Download(value.Key)
-				if err != nil {
-					return nil, err
-				}
-				return &adapter.ResolveResult{
-					Status: "value",
-					Value: &adapter.Value{
-						Type:       "file",
-						Format:     "json",
-						Path:       path,
-						References: adapterRefs,
-					},
-				}, nil
-			default:
-				return nil, fmt.Errorf("unknown value type: %s", value.Type)
-			}
-		case "error":
-			var errType, errMsg string
-			if len(arr) >= 2 {
-				errType, _ = arr[1].(string)
-			}
-			if len(arr) >= 3 {
-				errMsg, _ = arr[2].(string)
-			}
-			return &adapter.ResolveResult{
-				Status:       "error",
-				ErrorType:    errType,
-				ErrorMessage: errMsg,
-			}, nil
-		case "cancelled":
-			return &adapter.ResolveResult{Status: "cancelled"}, nil
-		case "dismissed":
-			return &adapter.ResolveResult{Status: "dismissed"}, nil
-		case "timeout":
-			return &adapter.ResolveResult{Status: "timeout"}, nil
-		case "suspended":
-			return &adapter.ResolveResult{Status: "suspended"}, nil
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected select result format: %T (%v)", result, result)
+	}
+
+	status := getString(resultMap["status"])
+	sel := &adapter.SelectResult{Status: status}
+
+	if raw, ok := resultMap["winner"]; ok {
+		if f, ok := raw.(float64); ok {
+			idx := int(f)
+			sel.Winner = &idx
 		}
 	}
 
-	return nil, fmt.Errorf("unexpected result format: %T (%v)", result, result)
+	switch status {
+	case "ok":
+		valueArr, ok := resultMap["value"].([]any)
+		if !ok {
+			return nil, fmt.Errorf("ok status missing value tuple: %v", resultMap)
+		}
+		value, err := api.ParseValue(valueArr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse value: %w", err)
+		}
+		adapterRefs, err := w.refsToAdapter(value.References)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert references: %w", err)
+		}
+		switch value.Type {
+		case api.ValueTypeRaw:
+			sel.Value = &adapter.Value{
+				Type:       "inline",
+				Format:     "json",
+				Value:      value.Content,
+				References: adapterRefs,
+			}
+		case api.ValueTypeBlob:
+			path, err := w.blobs.Download(value.Key)
+			if err != nil {
+				return nil, err
+			}
+			sel.Value = &adapter.Value{
+				Type:       "file",
+				Format:     "json",
+				Path:       path,
+				References: adapterRefs,
+			}
+		default:
+			return nil, fmt.Errorf("unknown value type: %s", value.Type)
+		}
+	case "error":
+		if errRaw, ok := resultMap["error"].(map[string]any); ok {
+			sel.Error = &adapter.ErrorDetail{
+				Type:      getString(errRaw["type"]),
+				Message:   getString(errRaw["message"]),
+				Traceback: getString(errRaw["traceback"]),
+			}
+		}
+	case "cancelled", "dismissed", "timeout":
+		// status-only
+	default:
+		return nil, fmt.Errorf("unknown select status: %s", status)
+	}
+
+	return sel, nil
 }
 
 func (w *Worker) SubmitInput(ctx context.Context, params *adapter.SubmitInputParams) (string, error) {
@@ -987,86 +984,6 @@ func (w *Worker) SubmitInput(ctx context.Context, params *adapter.SubmitInputPar
 		return "", fmt.Errorf("unexpected submit_input result: %T (%v)", result, result)
 	}
 	return inputExternalID, nil
-}
-
-func (w *Worker) ResolveInput(ctx context.Context, params *adapter.ResolveInputParams) (*adapter.ResolveResult, error) {
-	suspend := true
-	if params.Suspend != nil {
-		suspend = *params.Suspend
-	}
-
-	var result any
-	for {
-		conn, err := w.waitForConn(ctx)
-		if err != nil {
-			return nil, err
-		}
-		result, err = conn.Request(ctx, "resolve_input",
-			params.InputExternalID,
-			params.FromExecutionID,
-			params.TimeoutMs,
-			suspend,
-		)
-		if err != nil {
-			if isConnectionError(err) {
-				w.logger.Debug("retrying resolve_input after reconnect", "input", params.InputExternalID)
-				continue
-			}
-			return nil, err
-		}
-		break
-	}
-
-	// nil result means the wait expired with no result available (poll timeout)
-	if result == nil {
-		return nil, nil
-	}
-
-	// Result could be ["suspended"], ["dismissed"], ["value", json_value], etc.
-	if arr, ok := result.([]any); ok && len(arr) >= 1 {
-		resultType := getString(arr[0])
-		switch resultType {
-		case "value":
-			if len(arr) < 2 {
-				return nil, fmt.Errorf("value result missing value: %v", arr)
-			}
-			if arr[1] == nil {
-				return &adapter.ResolveResult{
-					Status: "value",
-					Value:  nil,
-				}, nil
-			}
-			return &adapter.ResolveResult{
-				Status: "value",
-				Value: &adapter.Value{
-					Type:   "inline",
-					Format: "json",
-					Value:  arr[1],
-				},
-			}, nil
-		case "error":
-			var errType, errMsg string
-			if len(arr) >= 2 {
-				errType, _ = arr[1].(string)
-			}
-			if len(arr) >= 3 {
-				errMsg, _ = arr[2].(string)
-			}
-			return &adapter.ResolveResult{
-				Status:       "error",
-				ErrorType:    errType,
-				ErrorMessage: errMsg,
-			}, nil
-		case "cancelled":
-			return &adapter.ResolveResult{Status: "cancelled"}, nil
-		case "dismissed":
-			return &adapter.ResolveResult{Status: "dismissed"}, nil
-		case "suspended":
-			return &adapter.ResolveResult{Status: "suspended"}, nil
-		}
-	}
-
-	return nil, fmt.Errorf("unexpected result format: %T (%v)", result, result)
 }
 
 func (w *Worker) PersistAsset(ctx context.Context, executionID string, paths []string, metadata map[string]any, preResolved map[string][]any) (map[string]any, error) {

--- a/cli/internal/worker/worker.go
+++ b/cli/internal/worker/worker.go
@@ -1101,12 +1101,13 @@ func (w *Worker) RegisterGroup(ctx context.Context, executionID string, groupID 
 	return conn.Notify("register_group", executionID, groupID, name)
 }
 
-func (w *Worker) CancelExecution(ctx context.Context, executionID string, targetExecutionID string) error {
-	conn, err := w.requireConn()
+func (w *Worker) Cancel(ctx context.Context, executionID string, handles []adapter.SelectHandle) error {
+	conn, err := w.waitForConn(ctx)
 	if err != nil {
 		return err
 	}
-	return conn.Notify("cancel", targetExecutionID)
+	_, err = conn.Request(ctx, "cancel", handles, executionID)
+	return err
 }
 
 func (w *Worker) RecordLog(ctx context.Context, executionID string, level int, template *string, values map[string]*adapter.Value) error {

--- a/docs/docs/python_reference.md
+++ b/docs/docs/python_reference.md
@@ -120,7 +120,7 @@ Returned by `target.submit()`. Represents a running or completed execution, and 
 
 Blocks (suspends) until the execution completes and returns the result. If the execution failed, raises the corresponding exception.
 
-**Raises:** `ExecutionError`, `ExecutionCancelled`, or `ExecutionTimeout`.
+**Raises:** `ExecutionError`, `ExecutionCancelled`, or `ExecutionTimeout`. If called inside a `cf.suspense(timeout=...)` scope and the timeout expires before the handle resolves, raises `TimeoutError`.
 
 ### `execution.poll(timeout=None, *, default=None) -> T | D`
 

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -288,17 +288,23 @@ defmodule Coflux.Handlers.Worker do
         end
 
       "cancel" ->
-        [execution_id] = message["params"]
+        [handles, from_execution_id] = message["params"]
 
-        case Orchestration.cancel_execution(state.project_id, state.workspace_id, execution_id) do
-          :ok ->
-            {[], state}
+        if is_recognised_execution?(from_execution_id, state) do
+          case Orchestration.cancel(
+                 state.project_id,
+                 handles,
+                 state.workspace_id,
+                 from_execution_id
+               ) do
+            :ok ->
+              {[success_message(message["id"], nil)], state}
 
-          {:error, :workspace_mismatch} ->
-            {[{:close, 4000, "workspace_mismatch"}], nil}
-
-          {:error, :not_found} ->
-            {[], state}
+            {:error, :workspace_not_found} ->
+              {[{:close, 4000, "workspace_mismatch"}], nil}
+          end
+        else
+          {[{:close, 4000, "execution_invalid"}], nil}
         end
 
       "suspend" ->

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -679,10 +679,7 @@ defmodule Coflux.Handlers.Worker do
         Map.put(base, "status", "dismissed")
 
       {:abandoned, _} ->
-        Map.merge(base, %{
-          "status" => "error",
-          "error" => compose_error("Abandoned", "Execution abandoned", [])
-        })
+        Map.put(base, "status", "abandoned")
 
       {:timeout, _} ->
         Map.put(base, "status", "timeout")

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -345,7 +345,7 @@ defmodule Coflux.Handlers.Worker do
               {[success_message(message["id"], compose_select_result(:timeout))], state}
 
             {:ok, :suspended} ->
-              # Respond with timeout status to unblock the pending RPC before
+              # Respond with a null result to unblock the pending RPC before
               # the separate :abort command terminates the executor. The
               # worker kills the process regardless; sending this response
               # just clears the pending request so the dispatch loop can exit.
@@ -640,16 +640,17 @@ defmodule Coflux.Handlers.Worker do
     end
   end
 
-  # Compose a select result for the CLI. Returns a JSON-compatible map.
+  # Compose a select result for the CLI. Returns a JSON-compatible map,
+  # or `nil` when the select wait itself expired (no handle resolved).
   # Payload is one of:
-  #   :timeout
+  #   :timeout                       (wait expired; `nil` on the wire)
   #   {handle_index, result_detail}
   #     where result_detail is one of:
   #       {:value, value}
   #       {:error, type, message, frames, retry_id, retryable?}
   #       :cancelled | :dismissed | {:abandoned, nil} | {:timeout, nil} | :suspended
   defp compose_select_result(:timeout) do
-    %{"status" => "timeout"}
+    nil
   end
 
   defp compose_select_result({idx, detail}) do

--- a/server/lib/coflux/handlers/worker.ex
+++ b/server/lib/coflux/handlers/worker.ex
@@ -318,30 +318,44 @@ defmodule Coflux.Handlers.Worker do
           {[{:close, 4000, "execution_invalid"}], nil}
         end
 
-      "get_result" ->
-        {execution_id, from_execution_id, timeout_ms, suspend} =
+      "select" ->
+        {handles, from_execution_id, timeout_ms, suspend, cancel_remaining} =
           case message["params"] do
-            [eid, feid, tms, s] -> {eid, feid, tms, s}
-            [eid, feid, tms] -> {eid, feid, tms, true}
+            [h, feid, tms, s, cr] -> {h, feid, tms, s, cr}
+            [h, feid, tms, s] -> {h, feid, tms, s, false}
           end
 
         if is_recognised_execution?(from_execution_id, state) do
-          case Orchestration.get_result(
+          case Orchestration.select(
                  state.project_id,
-                 execution_id,
+                 handles,
                  from_execution_id,
                  timeout_ms,
                  suspend,
+                 cancel_remaining,
                  message["id"]
                ) do
-            {:ok, nil} ->
-              {[success_message(message["id"], nil)], state}
+            {:ok, :timeout} ->
+              {[success_message(message["id"], compose_select_result(:timeout))], state}
 
-            {:ok, result} ->
-              {[success_message(message["id"], compose_result(result))], state}
+            {:ok, :suspended} ->
+              # Respond with timeout status to unblock the pending RPC before
+              # the separate :abort command terminates the executor. The
+              # worker kills the process regardless; sending this response
+              # just clears the pending request so the dispatch loop can exit.
+              {[success_message(message["id"], compose_select_result(:timeout))], state}
+
+            {:ok, {idx, result}} ->
+              {[success_message(message["id"], compose_select_result({idx, result}))], state}
 
             :wait ->
               {[], state}
+
+            {:error, :execution_not_found} ->
+              {[{:close, 4000, "execution_invalid"}], nil}
+
+            {:error, :input_not_found} ->
+              {[error_message(message["id"], "input_not_found")], state}
           end
         else
           {[{:close, 4000, "execution_invalid"}], nil}
@@ -387,47 +401,6 @@ defmodule Coflux.Handlers.Worker do
 
             {:error, :input_mismatch} ->
               {[error_message(message["id"], "input_mismatch")], state}
-          end
-        else
-          {[{:close, 4000, "execution_invalid"}], nil}
-        end
-
-      "resolve_input" ->
-        [input_external_id, from_execution_id, timeout_ms, suspend] =
-          message["params"]
-
-        if is_recognised_execution?(from_execution_id, state) do
-          case Orchestration.resolve_input(
-                 state.project_id,
-                 input_external_id,
-                 from_execution_id,
-                 timeout_ms,
-                 suspend,
-                 message["id"]
-               ) do
-            {:ok, nil} ->
-              {[success_message(message["id"], nil)], state}
-
-            {:ok, :suspended} ->
-              {[success_message(message["id"], ["suspended"])], state}
-
-            {:ok, {:value, value}} ->
-              {[success_message(message["id"], ["value", value])], state}
-
-            {:ok, :dismissed} ->
-              {[success_message(message["id"], ["dismissed"])], state}
-
-            :wait ->
-              {[], state}
-
-            {:error, :not_found} ->
-              {[error_message(message["id"], "input_not_found")], state}
-
-            {:error, :execution_not_found} ->
-              # The orchestration server evicted the caller execution between
-              # our is_recognised_execution? pre-check and the call. Close:
-              # the handler's view of the session is out of sync.
-              {[{:close, 4000, "execution_invalid"}], nil}
           end
         else
           {[{:close, 4000, "execution_invalid"}], nil}
@@ -511,20 +484,8 @@ defmodule Coflux.Handlers.Worker do
      ], state}
   end
 
-  def websocket_info({:result, request_id, nil}, state) do
-    {[success_message(request_id, nil)], state}
-  end
-
-  def websocket_info({:result, request_id, result}, state) do
-    {[success_message(request_id, compose_result(result))], state}
-  end
-
-  def websocket_info({:response, request_id, {:value, value}}, state) do
-    {[success_message(request_id, ["value", value])], state}
-  end
-
-  def websocket_info({:response, request_id, :dismissed}, state) do
-    {[success_message(request_id, ["dismissed"])], state}
+  def websocket_info({:result, request_id, payload}, state) do
+    {[success_message(request_id, compose_select_result(payload))], state}
   end
 
   def websocket_info({:abort, execution_external_id}, state) do
@@ -673,18 +634,85 @@ defmodule Coflux.Handlers.Worker do
     end
   end
 
-  defp compose_result(result) do
-    case result do
-      {:error, type, message, _frames, _retry_id, _retryable} -> ["error", type, message]
-      {:error, type, message, _frames, _retry_id} -> ["error", type, message]
-      {:value, value} -> ["value", compose_value(value)]
-      {:abandoned, nil} -> ["abandoned"]
-      :cancelled -> ["cancelled"]
-      :dismissed -> ["dismissed"]
-      {:timeout, nil} -> ["timeout"]
-      :suspended -> ["suspended"]
+  # Compose a select result for the CLI. Returns a JSON-compatible map.
+  # Payload is one of:
+  #   :timeout
+  #   {handle_index, result_detail}
+  #     where result_detail is one of:
+  #       {:value, value}
+  #       {:error, type, message, frames, retry_id, retryable?}
+  #       :cancelled | :dismissed | {:abandoned, nil} | {:timeout, nil} | :suspended
+  defp compose_select_result(:timeout) do
+    %{"status" => "timeout"}
+  end
+
+  defp compose_select_result({idx, detail}) do
+    base = %{"winner" => idx}
+
+    case detail do
+      {:value, value} ->
+        Map.merge(base, %{"status" => "ok", "value" => compose_value(value)})
+
+      {:error, type, message, frames, _retry_id, _retryable} ->
+        Map.merge(base, %{
+          "status" => "error",
+          "error" => compose_error(type, message, frames)
+        })
+
+      {:error, type, message, frames, _retry_id} ->
+        Map.merge(base, %{
+          "status" => "error",
+          "error" => compose_error(type, message, frames)
+        })
+
+      :cancelled ->
+        Map.put(base, "status", "cancelled")
+
+      :dismissed ->
+        Map.put(base, "status", "dismissed")
+
+      {:abandoned, _} ->
+        Map.merge(base, %{
+          "status" => "error",
+          "error" => compose_error("Abandoned", "Execution abandoned", [])
+        })
+
+      {:timeout, _} ->
+        Map.put(base, "status", "timeout")
+
+      :suspended ->
+        # Should not reach the client: suspension is signalled via :abort
+        # rather than as a winner status.
+        Map.put(base, "status", "timeout")
     end
   end
+
+  defp compose_error(type, message, frames) do
+    traceback = format_traceback(frames)
+
+    error = %{"type" => type, "message" => message}
+
+    if traceback != "" do
+      Map.put(error, "traceback", traceback)
+    else
+      error
+    end
+  end
+
+  defp format_traceback(frames) when is_list(frames) do
+    frames
+    |> Enum.map(fn
+      {file, line, name, code} ->
+        "  File \"#{file}\", line #{line}, in #{name}\n    #{code}"
+
+      _ ->
+        ""
+    end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp format_traceback(_), do: ""
 
   defp parse_websocket_protocols(req) do
     case :cowboy_req.parse_header("sec-websocket-protocol", req) do

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -150,6 +150,10 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:cancel_execution, workspace_id, execution_id, access})
   end
 
+  def cancel(project_id, handles, workspace_id, from_execution_id) do
+    call_server(project_id, {:cancel, handles, workspace_id, from_execution_id})
+  end
+
   def rerun_step(project_id, step_id, workspace_id, access \\ nil) do
     call_server(
       project_id,

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -177,10 +177,18 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:record_result, execution_id, result})
   end
 
-  def get_result(project_id, execution_id, from_execution_id, timeout_ms, suspend, request_id) do
+  def select(
+        project_id,
+        handles,
+        from_execution_id,
+        timeout_ms,
+        suspend,
+        cancel_remaining,
+        request_id
+      ) do
     call_server(
       project_id,
-      {:get_result, execution_id, from_execution_id, timeout_ms, suspend, request_id}
+      {:select, handles, from_execution_id, timeout_ms, suspend, cancel_remaining, request_id}
     )
   end
 
@@ -246,20 +254,6 @@ defmodule Coflux.Orchestration do
       project_id,
       {:submit_input, execution_id, template, placeholders, schema_json, key, title, actions,
        initial, requires}
-    )
-  end
-
-  def resolve_input(
-        project_id,
-        input_external_id,
-        from_execution_id,
-        timeout_ms,
-        suspend,
-        request_id
-      ) do
-    call_server(
-      project_id,
-      {:resolve_input, input_external_id, from_execution_id, timeout_ms, suspend, request_id}
     )
   end
 

--- a/server/lib/coflux/orchestration/inputs.ex
+++ b/server/lib/coflux/orchestration/inputs.ex
@@ -6,9 +6,11 @@ defmodule Coflux.Orchestration.Inputs do
   # Response types
   @type_value 1
   @type_dismissed 2
+  @type_cancelled 3
 
   def type_value, do: @type_value
   def type_dismissed, do: @type_dismissed
+  def type_cancelled, do: @type_cancelled
 
   # --- Schema deduplication ---
 
@@ -211,6 +213,9 @@ defmodule Coflux.Orchestration.Inputs do
 
       {:ok, {@type_dismissed, _value, created_at, created_by}} ->
         {:ok, {:dismissed, created_at, created_by}}
+
+      {:ok, {@type_cancelled, _value, created_at, created_by}} ->
+        {:ok, {:cancelled, created_at, created_by}}
     end
   end
 

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1578,6 +1578,26 @@ defmodule Coflux.Orchestration.Server do
     end
   end
 
+  def handle_call(
+        {:cancel, handles, workspace_external_id, _from_execution_external_id},
+        _from,
+        state
+      ) do
+    case Map.fetch(state.workspace_external_ids, workspace_external_id) do
+      :error ->
+        {:reply, {:error, :workspace_not_found}, state}
+
+      {:ok, workspace_id} ->
+        state =
+          Enum.reduce(handles, state, fn handle, state ->
+            cancel_handle(state, handle, workspace_id)
+          end)
+
+        state = flush_notifications(state)
+        {:reply, :ok, state}
+    end
+  end
+
   def handle_call({:execution_started, _external_execution_id, _metadata}, _from, state) do
     {:reply, :ok, state}
   end
@@ -1828,7 +1848,7 @@ defmodule Coflux.Orchestration.Server do
                 {:resolved, result} = Enum.at(statuses, resolved_index)
 
                 state =
-                  maybe_cancel_remaining_executions(
+                  maybe_cancel_remaining(
                     state,
                     statuses,
                     resolved_index,
@@ -3455,6 +3475,78 @@ defmodule Coflux.Orchestration.Server do
     cancel_descendants(state, execution_id, workspace_id)
   end
 
+  # Dispatch a single handle cancellation. Used by the unified cancel RPC
+  # and by maybe_cancel_remaining on select.
+  defp cancel_handle(state, %{"type" => "execution", "id" => ext_id}, workspace_id) do
+    case resolve_internal_execution_id(state, ext_id) do
+      {:ok, execution_id} ->
+        active_id = resolve_active_execution(state.db, execution_id)
+        do_cancel_execution(state, active_id, workspace_id)
+
+      {:error, :not_found} ->
+        state
+    end
+  end
+
+  defp cancel_handle(state, %{"type" => "input", "id" => ext_id}, _workspace_id) do
+    do_cancel_input(state, ext_id)
+  end
+
+  # Mark an input as cancelled. Parallels dismiss_input but with a distinct
+  # terminal state; notifies select waiters with :cancelled, resumes any
+  # suspended executions, and notifies topic subscribers.
+  defp do_cancel_input(state, input_external_id) do
+    case find_and_copy_input_from_archives(state, input_external_id) do
+      {:ok, nil} ->
+        state
+
+      {:ok,
+       {input_id, workspace_id, _key, _prompt_id, _schema_id, _title, _actions, _initial,
+        _requires_tag_set_id, _created_at, _run_id}} ->
+        now = System.system_time(:millisecond)
+
+        case Inputs.record_input_response(
+               state.db,
+               input_id,
+               Inputs.type_cancelled(),
+               nil,
+               now,
+               nil
+             ) do
+          {:ok, true} ->
+            state =
+              notify_select_waiters(state, {:input, input_external_id}, :cancelled)
+
+            state = update_dependencies_on_input(state, input_id)
+
+            {:ok, run_external_id, _input_number} =
+              parse_input_external_id(input_external_id)
+
+            ws_ext_id = workspace_external_id(state, workspace_id)
+
+            response = build_input_response(state.db, input_id)
+
+            state
+            |> notify_listeners(
+              {:run, run_external_id},
+              {:input_response, input_external_id, :cancelled}
+            )
+            |> notify_dependent_runs(input_id, input_external_id, :cancelled, run_external_id)
+            |> notify_listeners(
+              {:inputs, ws_ext_id},
+              {:input_responded, input_external_id, now}
+            )
+            |> notify_listeners(
+              {:input, input_external_id},
+              {:response, response}
+            )
+
+          {:error, :already_responded} ->
+            state
+        end
+    end
+  end
+
   # Cancel all active (unresolved) executions for a step in a workspace.
   defp cancel_active_step_executions(state, step_id, workspace_id) do
     {:ok, active_execution_ids} =
@@ -3941,6 +4033,7 @@ defmodule Coflux.Orchestration.Server do
                     {:ok, nil} -> nil
                     {:ok, {:value, _, _, _}} -> :value
                     {:ok, {:dismissed, _, _}} -> :dismissed
+                    {:ok, {:cancelled, _, _}} -> :cancelled
                   end
 
                 notify_listeners(
@@ -3997,6 +4090,7 @@ defmodule Coflux.Orchestration.Server do
   defp decode_input_response_type(nil), do: nil
   defp decode_input_response_type(1), do: :value
   defp decode_input_response_type(2), do: :dismissed
+  defp decode_input_response_type(3), do: :cancelled
 
   defp build_input_response(db, input_id) do
     case Inputs.get_input_response(db, input_id) do
@@ -4020,6 +4114,15 @@ defmodule Coflux.Orchestration.Server do
           end
 
         %{type: :dismissed, value: nil, created_at: created_at, created_by: principal}
+
+      {:ok, {:cancelled, created_at, created_by_id}} ->
+        principal =
+          case Principals.get_principal(db, created_by_id) do
+            {:ok, {type, external_id}} -> %{type: type, external_id: external_id}
+            {:ok, nil} -> nil
+          end
+
+        %{type: :cancelled, value: nil, created_at: created_at, created_by: principal}
     end
   end
 
@@ -6455,6 +6558,7 @@ defmodule Coflux.Orchestration.Server do
                 {:ok, nil} -> nil
                 {:ok, {:value, _, _, _}} -> :value
                 {:ok, {:dismissed, _, _}} -> :dismissed
+                {:ok, {:cancelled, _, _}} -> :cancelled
               end
 
             ws_ext_id = workspace_external_id(state, workspace_id)
@@ -6494,16 +6598,20 @@ defmodule Coflux.Orchestration.Server do
 
           {:ok, {:dismissed, _created_at, _created_by}} ->
             {{:ok, {:resolved, :dismissed}}, state}
+
+          {:ok, {:cancelled, _created_at, _created_by}} ->
+            {{:ok, {:resolved, :cancelled}}, state}
         end
     end
   end
 
-  # When cancel_remaining is true and a handle resolves, cancel any
-  # non-winner execution handles. Input handles are left pending.
-  defp maybe_cancel_remaining_executions(state, _statuses, _winner_idx, false, _from_ext_id),
+  # When cancel_remaining is true and a handle resolves, cancel all
+  # non-winner handles (executions via do_cancel_execution, inputs by
+  # marking them cancelled).
+  defp maybe_cancel_remaining(state, _statuses, _winner_idx, false, _from_ext_id),
     do: state
 
-  defp maybe_cancel_remaining_executions(
+  defp maybe_cancel_remaining(
          state,
          statuses,
          winner_idx,
@@ -6520,13 +6628,10 @@ defmodule Coflux.Orchestration.Server do
     |> Enum.reject(fn {_, idx} -> idx == winner_idx end)
     |> Enum.reduce(state, fn
       {{:pending, {:execution, ext_id}, _}, _idx}, state ->
-        case resolve_internal_execution_id(state, ext_id) do
-          {:ok, execution_id} ->
-            do_cancel_execution(state, execution_id, workspace_id)
+        cancel_handle(state, %{"type" => "execution", "id" => ext_id}, workspace_id)
 
-          {:error, :not_found} ->
-            state
-        end
+      {{:pending, {:input, ext_id}, _}, _idx}, state ->
+        cancel_handle(state, %{"type" => "input", "id" => ext_id}, workspace_id)
 
       {_, _}, state ->
         state

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1786,128 +1786,116 @@ defmodule Coflux.Orchestration.Server do
   end
 
   def handle_call(
-        {:get_result, execution_external_id, from_execution_external_id, timeout_ms, suspend,
+        {:select, handles, from_execution_external_id, timeout_ms, suspend, cancel_remaining,
          request_id},
         _from,
         state
       ) do
-    # Resolve external execution ID to internal
-    execution_id =
-      case resolve_internal_execution_id(state, execution_external_id) do
-        {:ok, id} -> {:ok, id}
-        {:error, :not_found} -> :error
-      end
+    case resolve_internal_execution_id(state, from_execution_external_id) do
+      {:error, :not_found} ->
+        {:reply, {:error, :execution_not_found}, state}
 
-    case execution_id do
-      :error ->
-        {:reply, {:error, :not_found}, state}
+      {:ok, from_execution_id} ->
+        # Process each handle: record dependency and determine status.
+        # Each entry is {:ok, status} or {:error, reason}.
+        {entries, state} =
+          Enum.map_reduce(handles, state, fn handle, state ->
+            process_select_handle(
+              state,
+              handle,
+              from_execution_id,
+              from_execution_external_id
+            )
+          end)
 
-      {:ok, execution_id} ->
-        # Resolve from_execution_id from external to internal only for DB calls
-        from_execution_id =
-          if from_execution_external_id do
-            case resolve_internal_execution_id(state, from_execution_external_id) do
-              {:ok, id} -> id
-              {:error, :not_found} -> nil
-            end
-          end
+        case Enum.find(entries, &match?({:error, _}, &1)) do
+          {:error, reason} ->
+            state = flush_notifications(state)
+            {:reply, {:error, reason}, state}
 
-        # TODO: check execution_id exists? (call resolve_result first?)
-        # TODO: require from_execution_id to be set if timeout_ms is specified?
+          nil ->
+            # Find first already-resolved handle (earliest in input order wins)
+            statuses = Enum.map(entries, fn {:ok, s} -> s end)
 
-        state =
-          if from_execution_id do
-            {:ok, dep_ref_id} = Runs.create_execution_ref_for(state.db, execution_id)
-            {:ok, id} = Runs.record_result_dependency(state.db, from_execution_id, dep_ref_id)
+            resolved_index =
+              Enum.find_index(statuses, fn
+                {:resolved, _} -> true
+                _ -> false
+              end)
 
-            if id do
-              {:ok, {run_external_id}} =
-                Runs.get_external_run_id_for_execution(state.db, from_execution_id)
+            cond do
+              resolved_index != nil ->
+                {:resolved, result} = Enum.at(statuses, resolved_index)
 
-              # TODO: only resolve if there are listeners to notify
-              {dep_ext_id, _module, _target} =
-                dependency =
-                resolve_execution_ref(state.db, dep_ref_id)
+                state =
+                  maybe_cancel_remaining_executions(
+                    state,
+                    statuses,
+                    resolved_index,
+                    cancel_remaining,
+                    from_execution_external_id
+                  )
 
-              notify_listeners(
-                state,
-                {:run, run_external_id},
-                {:result_dependency, from_execution_external_id, dep_ext_id, dependency}
-              )
-            else
-              state
-            end
-          else
-            state
-          end
+                state = flush_notifications(state)
+                {:reply, {:ok, {resolved_index, result}}, state}
 
-        {result, state} =
-          case resolve_result(state.db, execution_id) do
-            {:pending, pending_execution_id} ->
-              cond do
-                timeout_ms == 0 && suspend ->
-                  # Immediate suspend
-                  {:ok, state} =
-                    process_result(
-                      state,
-                      from_execution_id,
-                      {:suspended, nil, [{:execution, pending_execution_id}]}
-                    )
+              timeout_ms == 0 && suspend ->
+                dependency_keys =
+                  Enum.map(statuses, fn {:pending, _waiting_key, dep_key} -> dep_key end)
 
-                  {{:ok, :suspended}, state}
+                {:ok, state} =
+                  process_result(
+                    state,
+                    from_execution_id,
+                    {:suspended, nil, dependency_keys}
+                  )
 
-                timeout_ms == 0 ->
-                  # Immediate poll: no result available
-                  {{:ok, nil}, state}
+                state = flush_notifications(state)
+                {:reply, {:ok, :suspended}, state}
 
-                true ->
-                  # Wait for result (with or without timeout)
-                  now = System.monotonic_time(:millisecond)
-                  expire_at = if timeout_ms, do: now + timeout_ms
+              timeout_ms == 0 ->
+                state = flush_notifications(state)
+                {:reply, {:ok, :timeout}, state}
 
-                  # Use the external ID of the *resolved* pending execution as the waiting key.
-                  # This is critical for spawned chains: resolve_result follows
-                  # initial→spawned and returns the spawned execution's ID, which is
-                  # the one that will eventually complete and trigger notify_waiting.
-                  pending_ext_id =
-                    case Runs.get_execution_key(state.db, pending_execution_id) do
-                      {:ok, {r, s, a}} -> execution_external_id(r, s, a)
-                    end
+              true ->
+                now = System.monotonic_time(:millisecond)
+                expire_at = if timeout_ms, do: now + timeout_ms
 
-                  waiting_key = {:execution, pending_ext_id}
+                waiting_keys =
+                  Enum.map(statuses, fn {:pending, waiting_key, _} -> waiting_key end)
 
-                  state =
+                state =
+                  statuses
+                  |> Enum.with_index()
+                  |> Enum.reduce(state, fn {{:pending, waiting_key, _}, idx}, state ->
+                    entry = %{
+                      from_ext_id: from_execution_external_id,
+                      request_id: request_id,
+                      expire_at: expire_at,
+                      suspend: suspend,
+                      cancel_remaining: cancel_remaining,
+                      handle_index: idx,
+                      keys: waiting_keys
+                    }
+
                     update_in(
                       state,
                       [Access.key(:waiting), Access.key(waiting_key, [])],
-                      &[{from_execution_external_id, request_id, expire_at, suspend} | &1]
+                      &[entry | &1]
                     )
+                  end)
 
-                  state =
-                    if timeout_ms do
-                      reschedule_expire_waiters(state)
-                    else
-                      state
-                    end
+                state =
+                  if timeout_ms do
+                    reschedule_expire_waiters(state)
+                  else
+                    state
+                  end
 
-                  {:wait, state}
-              end
-
-            {:ok, result} ->
-              # Only enrich value results with resolved references (asset metadata, execution metadata)
-              # Other result types (error, abandoned, etc.) don't need enrichment for the client
-              result =
-                case result do
-                  {:value, value} -> {:value, build_value(value, state.db)}
-                  other -> other
-                end
-
-              {{:ok, result}, state}
-          end
-
-        state = flush_notifications(state)
-
-        {:reply, result, state}
+                state = flush_notifications(state)
+                {:reply, :wait, state}
+            end
+        end
     end
   end
 
@@ -2042,124 +2030,6 @@ defmodule Coflux.Orchestration.Server do
     end
   end
 
-  def handle_call(
-        {:resolve_input, input_external_id, from_execution_external_id, timeout_ms, suspend,
-         request_id},
-        _from,
-        state
-      ) do
-    case find_and_copy_input_from_archives(state, input_external_id) do
-      {:ok, nil} ->
-        {:reply, {:error, :not_found}, state}
-
-      {:ok,
-       {input_id, workspace_id, _key, _prompt_id, _schema_id, title, _actions, _initial,
-        requires_tag_set_id, created_at, _run_id}} ->
-        case resolve_internal_execution_id(state, from_execution_external_id) do
-          {:error, :not_found} ->
-            {:reply, {:error, :execution_not_found}, state}
-
-          {:ok, from_execution_id} ->
-            now = System.system_time(:millisecond)
-
-            # Fetch response once and reuse below
-            input_response = Inputs.get_input_response(state.db, input_id)
-
-            # Record dependency and notify
-            {:ok, is_new} =
-              Inputs.record_input_dependency(state.db, from_execution_id, input_id, now)
-
-            state =
-              if is_new do
-                {:ok, {run_external_id}} =
-                  Runs.get_external_run_id_for_execution(state.db, from_execution_id)
-
-                response_type =
-                  case input_response do
-                    {:ok, nil} -> nil
-                    {:ok, {:value, _, _, _}} -> :value
-                    {:ok, {:dismissed, _, _}} -> :dismissed
-                  end
-
-                ws_ext_id = workspace_external_id(state, workspace_id)
-
-                requires = resolve_tag_set(state.db, requires_tag_set_id)
-
-                state
-                |> notify_listeners(
-                  {:run, run_external_id},
-                  {:input_dependency, from_execution_external_id, input_external_id, title,
-                   response_type}
-                )
-                |> notify_listeners(
-                  {:inputs, ws_ext_id},
-                  {:input_dependency_active, input_external_id, run_external_id, created_at,
-                   title, requires}
-                )
-                |> notify_listeners(
-                  {:input, input_external_id},
-                  {:active, true}
-                )
-              else
-                state
-              end
-
-            # Check for existing response
-            case input_response do
-              {:ok, nil} ->
-                # No response yet — wait or suspend
-                cond do
-                  timeout_ms == 0 && suspend ->
-                    {:ok, state} =
-                      process_result(
-                        state,
-                        from_execution_id,
-                        {:suspended, nil, [{:input, input_id}]}
-                      )
-
-                    state = flush_notifications(state)
-                    {:reply, {:ok, :suspended}, state}
-
-                  timeout_ms == 0 ->
-                    state = flush_notifications(state)
-                    {:reply, {:ok, nil}, state}
-
-                  true ->
-                    monotonic_now = System.monotonic_time(:millisecond)
-                    expire_at = if timeout_ms, do: monotonic_now + timeout_ms
-
-                    waiting_key = {:input, input_external_id}
-
-                    state =
-                      update_in(
-                        state,
-                        [Access.key(:waiting), Access.key(waiting_key, [])],
-                        &[{from_execution_external_id, request_id, expire_at, suspend} | &1]
-                      )
-
-                    state =
-                      if timeout_ms do
-                        reschedule_expire_waiters(state)
-                      else
-                        state
-                      end
-
-                    state = flush_notifications(state)
-                    {:reply, :wait, state}
-                end
-
-              {:ok, {:value, value, _created_at, _created_by}} ->
-                state = flush_notifications(state)
-                {:reply, {:ok, {:value, value}}, state}
-
-              {:ok, {:dismissed, _created_at, _created_by}} ->
-                state = flush_notifications(state)
-                {:reply, {:ok, :dismissed}, state}
-            end
-        end
-    end
-  end
-
   def handle_call({:respond_input, input_external_id, value, access}, _from, state) do
     case find_and_copy_input_from_archives(state, input_external_id) do
       {:ok, nil} ->
@@ -2189,21 +2059,15 @@ defmodule Coflux.Orchestration.Server do
                  created_by
                ) do
             {:ok, true} ->
-              # Notify waiters
-              waiting_key = {:input, input_external_id}
-              {input_waiting, waiting} = Map.pop(state.waiting, waiting_key, [])
-              state = Map.put(state, :waiting, waiting)
-
+              # Notify select waiters for this input. Wrap the raw JSON value
+              # in the tuple format so compose_value handles inputs and
+              # executions uniformly.
               state =
-                Enum.reduce(input_waiting, state, fn {from_ext_id, request_id, _, _}, state ->
-                  case find_session_for_execution(state, from_ext_id) do
-                    {:ok, session_id} ->
-                      send_session(state, session_id, {:response, request_id, {:value, value}})
-
-                    :error ->
-                      state
-                  end
-                end)
+                notify_select_waiters(
+                  state,
+                  {:input, input_external_id},
+                  {:value, {:raw, value, []}}
+                )
 
               # Resolve input dependency for any suspended executions waiting on this input
               state = update_dependencies_on_input(state, input_id)
@@ -2352,21 +2216,9 @@ defmodule Coflux.Orchestration.Server do
                created_by
              ) do
           {:ok, true} ->
-            # Cancel waiters
-            waiting_key = {:input, input_external_id}
-            {input_waiting, waiting} = Map.pop(state.waiting, waiting_key, [])
-            state = Map.put(state, :waiting, waiting)
-
+            # Notify select waiters for this input (dismissed)
             state =
-              Enum.reduce(input_waiting, state, fn {from_ext_id, request_id, _, _}, state ->
-                case find_session_for_execution(state, from_ext_id) do
-                  {:ok, session_id} ->
-                    send_session(state, session_id, {:response, request_id, :dismissed})
-
-                  :error ->
-                    state
-                end
-              end)
+              notify_select_waiters(state, {:input, input_external_id}, :dismissed)
 
             # Resolve input dependency for any suspended executions waiting on this input
             state = update_dependencies_on_input(state, input_id)
@@ -3383,112 +3235,85 @@ defmodule Coflux.Orchestration.Server do
   def handle_info(:expire_waiters, state) do
     now = System.monotonic_time(:millisecond)
 
-    # state.waiting keys are tagged tuples: {:execution, ext_id} or {:input, ext_id}.
-    # Collect expired entries, grouped by the waiter's execution ext_id, with the
-    # dependency keys they were waiting on.
-    {to_suspend, to_notify_not_ready} =
-      Enum.reduce(
-        state.waiting,
-        {%{}, []},
-        fn {dependency_key, execution_waiting}, {to_suspend, to_notify} ->
-          Enum.reduce(
-            execution_waiting,
-            {to_suspend, to_notify},
-            fn {from_ext_id, request_id, expire_at, suspend_flag}, {to_suspend, to_notify} ->
-              if expire_at && expire_at <= now do
-                if suspend_flag do
-                  {Map.update(
-                     to_suspend,
-                     from_ext_id,
-                     [dependency_key],
-                     &[dependency_key | &1]
-                   ), to_notify}
-                else
-                  {to_suspend, [{from_ext_id, request_id} | to_notify]}
-                end
-              else
-                {to_suspend, to_notify}
-              end
-            end
-          )
-        end
-      )
-
-    # Remove only non-suspend expired entries from waiting map.
-    # Suspend entries are left for cleanup_execution (inside abort_execution)
-    # to find and respond to.
-    state =
-      update_in(state, [Access.key(:waiting)], fn waiting ->
-        waiting
-        |> Enum.map(fn {key, entries} ->
-          remaining =
-            Enum.reject(entries, fn {_, _, expire_at, suspend_flag} ->
-              expire_at && expire_at <= now && !suspend_flag
-            end)
-
-          {key, remaining}
+    # Collect expired select waiters. Each waiter is registered under multiple
+    # keys (one per handle), so we dedupe by request_id. For suspend waiters,
+    # we collect the full set of dependency keys (for process_result); for
+    # poll waiters, we just need the request_id once.
+    expired =
+      Enum.reduce(state.waiting, %{}, fn {_waiting_key, entries}, acc ->
+        Enum.reduce(entries, acc, fn entry, acc ->
+          if entry.expire_at && entry.expire_at <= now do
+            Map.put_new(acc, entry.request_id, entry)
+          else
+            acc
+          end
         end)
-        |> Enum.reject(fn {_, entries} -> entries == [] end)
-        |> Map.new()
       end)
 
-    # Handle poll (non-suspend) timeouts: send nil result (no result available)
-    state =
-      Enum.reduce(
-        to_notify_not_ready,
-        state,
-        fn {from_ext_id, request_id}, state ->
-          case find_session_for_execution(state, from_ext_id) do
-            {:ok, session_id} ->
-              send_session(state, session_id, {:result, request_id, nil})
-
-            :error ->
-              state
-          end
+    {to_suspend, to_timeout} =
+      Enum.reduce(expired, {[], []}, fn {_, entry}, {to_suspend, to_timeout} ->
+        if entry.suspend do
+          {[entry | to_suspend], to_timeout}
+        else
+          {to_suspend, [entry | to_timeout]}
         end
-      )
+      end)
 
-    # Handle suspend timeouts: record suspension and abort
-    # (abort_execution → cleanup_execution sends the :suspended response
-    # for any pending requests found in the waiting map)
+    # Remove expired poll (non-suspend) waiters from all keys they're
+    # registered under. Suspend waiters are cleared when process_result →
+    # abort_execution → cleanup_execution runs.
     state =
-      Enum.reduce(
-        to_suspend,
-        state,
-        fn {from_ext_id, dependency_keys}, state ->
-          from_execution_id = Map.fetch!(state.execution_ids, from_ext_id)
+      Enum.reduce(to_timeout, state, fn entry, state ->
+        Enum.reduce(entry.keys, state, fn key, state ->
+          remove_waiter_from_key(state, key, entry.request_id)
+        end)
+      end)
 
-          # Resolve each tagged external dependency to the internal form expected
-          # by process_result. Drop any dependencies we can't resolve (e.g. the
-          # execution or input has since been evicted).
-          internal_dependency_keys =
-            Enum.flat_map(dependency_keys, fn
-              {:input, input_ext_id} ->
-                with {:ok, run_ext_id, input_number} <- parse_input_external_id(input_ext_id),
-                     {:ok, id} <-
-                       Inputs.get_input_id_by_run_and_number(state.db, run_ext_id, input_number) do
-                  [{:input, id}]
-                else
-                  _ -> []
-                end
+    # Send timeout responses to poll waiters
+    state =
+      Enum.reduce(to_timeout, state, fn entry, state ->
+        case find_session_for_execution(state, entry.from_ext_id) do
+          {:ok, session_id} ->
+            send_session(state, session_id, {:result, entry.request_id, :timeout})
 
-              {:execution, dep_ext_id} ->
-                case resolve_internal_execution_id(state, dep_ext_id) do
-                  {:ok, id} -> [{:execution, id}]
-                  {:error, :not_found} -> []
-                end
-            end)
-
-          {:ok, state} =
-            process_result(
-              state,
-              from_execution_id,
-              {:suspended, nil, internal_dependency_keys}
-            )
-
-          state
+          :error ->
+            state
         end
-      )
+      end)
+
+    # Suspend waiters: record suspension with the dependency keys they were
+    # waiting on (so the execution can be resumed when any fires).
+    state =
+      Enum.reduce(to_suspend, state, fn entry, state ->
+        from_execution_id = Map.fetch!(state.execution_ids, entry.from_ext_id)
+
+        dependency_keys =
+          Enum.flat_map(entry.keys, fn
+            {:input, input_ext_id} ->
+              with {:ok, run_ext_id, input_number} <- parse_input_external_id(input_ext_id),
+                   {:ok, id} <-
+                     Inputs.get_input_id_by_run_and_number(state.db, run_ext_id, input_number) do
+                [{:input, id}]
+              else
+                _ -> []
+              end
+
+            {:execution, dep_ext_id} ->
+              case resolve_internal_execution_id(state, dep_ext_id) do
+                {:ok, id} -> [{:execution, id}]
+                {:error, :not_found} -> []
+              end
+          end)
+
+        {:ok, state} =
+          process_result(
+            state,
+            from_execution_id,
+            {:suspended, nil, dependency_keys}
+          )
+
+        state
+      end)
 
     state =
       state
@@ -3828,18 +3653,16 @@ defmodule Coflux.Orchestration.Server do
       |> Map.update!(:session_ids, &Map.delete(&1, session.external_id))
       |> Map.update!(:waiting, fn waiting ->
         # waiting keys are tagged tuples ({:execution, _} | {:input, _});
-        # from_execution_ids are external execution IDs.
+        # each entry is a select waiter map keyed by from_ext_id (external).
         waiting
-        |> Enum.map(fn {waiting_key, execution_waiting} ->
+        |> Enum.map(fn {waiting_key, entries} ->
           {waiting_key,
-           Enum.reject(execution_waiting, fn {from_ext_id, _, _, _} ->
-             MapSet.member?(session.starting, from_ext_id) ||
-               MapSet.member?(session.executing, from_ext_id)
+           Enum.reject(entries, fn entry ->
+             MapSet.member?(session.starting, entry.from_ext_id) ||
+               MapSet.member?(session.executing, entry.from_ext_id)
            end)}
         end)
-        |> Enum.reject(fn {_waiting_key, execution_waiting} ->
-          Enum.empty?(execution_waiting)
-        end)
+        |> Enum.reject(fn {_waiting_key, entries} -> entries == [] end)
         |> Map.new()
       end)
       |> notify_listeners(
@@ -6484,8 +6307,8 @@ defmodule Coflux.Orchestration.Server do
     next_expire_at =
       state.waiting
       |> Map.values()
-      |> Enum.flat_map(fn execution_waiting ->
-        Enum.map(execution_waiting, fn {_, _, expire_at, _} -> expire_at end)
+      |> Enum.flat_map(fn entries ->
+        Enum.map(entries, & &1.expire_at)
       end)
       |> Enum.reject(&is_nil/1)
       |> Enum.min(fn -> nil end)
@@ -6499,71 +6322,349 @@ defmodule Coflux.Orchestration.Server do
   end
 
   defp notify_waiting(state, execution_id) do
-    # Translate the internal execution_id to the tagged external-id key used in
-    # state.waiting ({:execution, ext_id}).
     execution_ext_id =
       case Runs.get_execution_key(state.db, execution_id) do
         {:ok, {r, s, a}} -> execution_external_id(r, s, a)
         {:error, :not_found} -> nil
       end
 
-    {execution_waiting, waiting} =
-      if execution_ext_id do
-        Map.pop(state.waiting, {:execution, execution_ext_id})
-      else
-        {nil, state.waiting}
+    if execution_ext_id do
+      old_key = {:execution, execution_ext_id}
+
+      case Map.get(state.waiting, old_key) do
+        nil ->
+          state
+
+        _entries ->
+          case resolve_result(state.db, execution_id) do
+            {:pending, new_execution_id} ->
+              # Execution was replaced by a spawned one — migrate waiters from
+              # the old key to the new one, updating their keys lists.
+              new_ext_id =
+                case Runs.get_execution_key(state.db, new_execution_id) do
+                  {:ok, {r, s, a}} -> execution_external_id(r, s, a)
+                end
+
+              new_key = {:execution, new_ext_id}
+              migrate_select_waiters(state, old_key, new_key)
+
+            {:ok, result} ->
+              result =
+                case result do
+                  {:value, value} -> {:value, build_value(value, state.db)}
+                  other -> other
+                end
+
+              notify_select_waiters(state, old_key, result)
+          end
       end
+    else
+      state
+    end
+  end
 
-    if execution_waiting do
-      state =
+  # Process a single handle for select: record the dependency and determine
+  # current status. Returns one of:
+  #   {:ok, {:resolved, result}}
+  #       where result is {:value, _} | {:error, ...} | :cancelled | :dismissed | ...
+  #   {:ok, {:pending, waiting_key, dependency_key}}
+  #       waiting_key identifies this handle in state.waiting
+  #       dependency_key is used when suspending (for process_result)
+  #   {:error, reason}
+  defp process_select_handle(
+         state,
+         %{"type" => "execution", "id" => execution_external_id},
+         from_execution_id,
+         from_execution_external_id
+       ) do
+    case resolve_internal_execution_id(state, execution_external_id) do
+      {:error, :not_found} ->
+        {{:error, :not_found}, state}
+
+      {:ok, execution_id} ->
+        {:ok, dep_ref_id} = Runs.create_execution_ref_for(state.db, execution_id)
+        {:ok, id} = Runs.record_result_dependency(state.db, from_execution_id, dep_ref_id)
+
+        state =
+          if id do
+            {:ok, {run_external_id}} =
+              Runs.get_external_run_id_for_execution(state.db, from_execution_id)
+
+            {dep_ext_id, _module, _target} =
+              dependency = resolve_execution_ref(state.db, dep_ref_id)
+
+            notify_listeners(
+              state,
+              {:run, run_external_id},
+              {:result_dependency, from_execution_external_id, dep_ext_id, dependency}
+            )
+          else
+            state
+          end
+
         case resolve_result(state.db, execution_id) do
-          {:pending, new_execution_id} ->
-            # Find the external ID for the new execution
-            new_ext_id =
-              case Runs.get_execution_key(state.db, new_execution_id) do
-                {:ok, {r, s, a}} -> execution_external_id(r, s, a)
-              end
-
-            waiting =
-              Map.update(
-                waiting,
-                {:execution, new_ext_id},
-                execution_waiting,
-                &(&1 ++ execution_waiting)
-              )
-
-            Map.put(state, :waiting, waiting)
-
           {:ok, result} ->
-            state = Map.put(state, :waiting, waiting)
-
-            # Enrich value results with resolved references (asset metadata, execution metadata)
             result =
               case result do
                 {:value, value} -> {:value, build_value(value, state.db)}
                 other -> other
               end
 
-            Enum.reduce(
-              execution_waiting,
-              state,
-              fn {from_ext_id, request_id, _, _}, state ->
-                # find_session_for_execution now uses external IDs
-                case find_session_for_execution(state, from_ext_id) do
-                  {:ok, session_id} ->
-                    send_session(state, session_id, {:result, request_id, result})
+            {{:ok, {:resolved, result}}, state}
 
-                  :error ->
-                    state
-                end
+          {:pending, pending_execution_id} ->
+            pending_ext_id =
+              case Runs.get_execution_key(state.db, pending_execution_id) do
+                {:ok, {r, s, a}} -> execution_external_id(r, s, a)
               end
+
+            {
+              {:ok, {:pending, {:execution, pending_ext_id}, {:execution, pending_execution_id}}},
+              state
+            }
+        end
+    end
+  end
+
+  defp process_select_handle(
+         state,
+         %{"type" => "input", "id" => input_external_id},
+         from_execution_id,
+         from_execution_external_id
+       ) do
+    case find_and_copy_input_from_archives(state, input_external_id) do
+      {:ok, nil} ->
+        {{:error, :input_not_found}, state}
+
+      {:ok,
+       {input_id, workspace_id, _key, _prompt_id, _schema_id, title, _actions, _initial,
+        requires_tag_set_id, created_at, _run_id}} ->
+        now = System.system_time(:millisecond)
+        input_response = Inputs.get_input_response(state.db, input_id)
+
+        {:ok, is_new} =
+          Inputs.record_input_dependency(state.db, from_execution_id, input_id, now)
+
+        state =
+          if is_new do
+            {:ok, {run_external_id}} =
+              Runs.get_external_run_id_for_execution(state.db, from_execution_id)
+
+            response_type =
+              case input_response do
+                {:ok, nil} -> nil
+                {:ok, {:value, _, _, _}} -> :value
+                {:ok, {:dismissed, _, _}} -> :dismissed
+              end
+
+            ws_ext_id = workspace_external_id(state, workspace_id)
+            requires = resolve_tag_set(state.db, requires_tag_set_id)
+
+            state
+            |> notify_listeners(
+              {:run, run_external_id},
+              {:input_dependency, from_execution_external_id, input_external_id, title,
+               response_type}
             )
+            |> notify_listeners(
+              {:inputs, ws_ext_id},
+              {:input_dependency_active, input_external_id, run_external_id, created_at, title,
+               requires}
+            )
+            |> notify_listeners(
+              {:input, input_external_id},
+              {:active, true}
+            )
+          else
+            state
+          end
+
+        case input_response do
+          {:ok, nil} ->
+            {
+              {:ok, {:pending, {:input, input_external_id}, {:input, input_id}}},
+              state
+            }
+
+          {:ok, {:value, value, _created_at, _created_by}} ->
+            # Input values are raw decoded JSON; wrap in the value tuple format
+            # so compose_value treats them uniformly with execution values.
+            wrapped = {:raw, value, []}
+            {{:ok, {:resolved, {:value, wrapped}}}, state}
+
+          {:ok, {:dismissed, _created_at, _created_by}} ->
+            {{:ok, {:resolved, :dismissed}}, state}
+        end
+    end
+  end
+
+  # When cancel_remaining is true and a handle resolves, cancel any
+  # non-winner execution handles. Input handles are left pending.
+  defp maybe_cancel_remaining_executions(state, _statuses, _winner_idx, false, _from_ext_id),
+    do: state
+
+  defp maybe_cancel_remaining_executions(
+         state,
+         statuses,
+         winner_idx,
+         true,
+         from_execution_external_id
+       ) do
+    {:ok, from_execution_id} =
+      resolve_internal_execution_id(state, from_execution_external_id)
+
+    {:ok, workspace_id} = Runs.get_workspace_id_for_execution(state.db, from_execution_id)
+
+    statuses
+    |> Enum.with_index()
+    |> Enum.reject(fn {_, idx} -> idx == winner_idx end)
+    |> Enum.reduce(state, fn
+      {{:pending, {:execution, ext_id}, _}, _idx}, state ->
+        case resolve_internal_execution_id(state, ext_id) do
+          {:ok, execution_id} ->
+            do_cancel_execution(state, execution_id, workspace_id)
+
+          {:error, :not_found} ->
+            state
         end
 
-      reschedule_expire_waiters(state)
-    else
-      state
+      {_, _}, state ->
+        state
+    end)
+  end
+
+  # Pop all select waiters registered under `waiting_key` and serve each one
+  # with `result`. Removes the waiters from any other keys they're
+  # registered under and cancels remaining executions when requested.
+  defp notify_select_waiters(state, waiting_key, result) do
+    {entries, waiting} = Map.pop(state.waiting, waiting_key, [])
+    state = Map.put(state, :waiting, waiting)
+
+    state =
+      Enum.reduce(entries, state, fn entry, state ->
+        serve_select_entry(state, entry, waiting_key, result)
+      end)
+
+    reschedule_expire_waiters(state)
+  end
+
+  # Serve a single waiter entry: clean it up from its other registration
+  # keys, optionally cancel non-winner executions, and notify the waiter's
+  # session.
+  defp serve_select_entry(state, entry, winner_key, result) do
+    state =
+      entry.keys
+      |> Enum.reject(&(&1 == winner_key))
+      |> Enum.reduce(state, fn key, state ->
+        remove_waiter_from_key(state, key, entry.request_id)
+      end)
+
+    state =
+      if entry.cancel_remaining do
+        cancel_other_execution_keys(state, entry, winner_key)
+      else
+        state
+      end
+
+    case find_session_for_execution(state, entry.from_ext_id) do
+      {:ok, session_id} ->
+        send_session(
+          state,
+          session_id,
+          {:result, entry.request_id, {entry.handle_index, result}}
+        )
+
+      :error ->
+        state
     end
+  end
+
+  defp remove_waiter_from_key(state, key, request_id) do
+    update_in(state, [Access.key(:waiting)], fn waiting ->
+      case Map.fetch(waiting, key) do
+        {:ok, entries} ->
+          remaining = Enum.reject(entries, &(&1.request_id == request_id))
+
+          if remaining == [] do
+            Map.delete(waiting, key)
+          else
+            Map.put(waiting, key, remaining)
+          end
+
+        :error ->
+          waiting
+      end
+    end)
+  end
+
+  defp cancel_other_execution_keys(state, entry, winner_key) do
+    {:ok, from_execution_id} =
+      resolve_internal_execution_id(state, entry.from_ext_id)
+
+    {:ok, workspace_id} = Runs.get_workspace_id_for_execution(state.db, from_execution_id)
+
+    entry.keys
+    |> Enum.reject(&(&1 == winner_key))
+    |> Enum.reduce(state, fn
+      {:execution, ext_id}, state ->
+        case resolve_internal_execution_id(state, ext_id) do
+          {:ok, execution_id} ->
+            do_cancel_execution(state, execution_id, workspace_id)
+
+          {:error, :not_found} ->
+            state
+        end
+
+      {:input, _}, state ->
+        state
+    end)
+  end
+
+  # Move all waiters from `old_key` to `new_key`, updating each entry's
+  # `keys` list. Used when an execution is replaced by a spawned one.
+  defp migrate_select_waiters(state, old_key, new_key) do
+    {entries, waiting} = Map.pop(state.waiting, old_key, [])
+
+    migrated =
+      Enum.map(entries, fn entry ->
+        Map.update!(entry, :keys, fn keys ->
+          Enum.map(keys, fn
+            ^old_key -> new_key
+            other -> other
+          end)
+        end)
+      end)
+
+    waiting =
+      Map.update(waiting, new_key, migrated, &(&1 ++ migrated))
+
+    state = Map.put(state, :waiting, waiting)
+
+    # Also update other key entries that reference old_key in their keys list
+    # (waiters registered under multiple keys, one of which was old_key).
+    update_in(state, [Access.key(:waiting)], fn waiting ->
+      Map.new(waiting, fn {key, entries} ->
+        if key == new_key do
+          {key, entries}
+        else
+          updated =
+            Enum.map(entries, fn entry ->
+              if old_key in entry.keys do
+                Map.update!(entry, :keys, fn keys ->
+                  Enum.map(keys, fn
+                    ^old_key -> new_key
+                    other -> other
+                  end)
+                end)
+              else
+                entry
+              end
+            end)
+
+          {key, updated}
+        end
+      end)
+    end)
   end
 
   # Finds the session for an execution by external execution ID
@@ -6585,42 +6686,41 @@ defmodule Coflux.Orchestration.Server do
   # Clean up waiting map entries and pending requests for an execution,
   # without sending an abort message to the worker.
   defp cleanup_execution(state, execution_ext_id) do
-    # Clean up waiting map entries where this execution is the waiter,
-    # and collect pending request IDs so we can send responses
-    {state, pending_request_ids} =
-      Enum.reduce(
-        state.waiting,
-        {state, []},
-        fn {waiting_key, execution_waiting}, {state, pending} ->
-          {removed, remaining} =
-            Enum.split_with(execution_waiting, fn {from_ext_id, _, _, _} ->
-              from_ext_id == execution_ext_id
-            end)
+    # Remove all select waiters where this execution is the waiter, deduping
+    # by request_id since each waiter may be registered under multiple keys.
+    removed_by_request =
+      Enum.reduce(state.waiting, %{}, fn {_key, entries}, acc ->
+        Enum.reduce(entries, acc, fn entry, acc ->
+          if entry.from_ext_id == execution_ext_id do
+            Map.put_new(acc, entry.request_id, entry)
+          else
+            acc
+          end
+        end)
+      end)
 
-          pending =
-            Enum.reduce(removed, pending, fn {_, request_id, _, _}, acc ->
-              if request_id, do: [request_id | acc], else: acc
-            end)
+    state =
+      Map.update!(state, :waiting, fn waiting ->
+        waiting
+        |> Enum.map(fn {key, entries} ->
+          {key, Enum.reject(entries, &(&1.from_ext_id == execution_ext_id))}
+        end)
+        |> Enum.reject(fn {_key, entries} -> entries == [] end)
+        |> Map.new()
+      end)
 
-          state =
-            Map.update!(state, :waiting, fn waiting ->
-              if Enum.any?(remaining) do
-                Map.put(waiting, waiting_key, remaining)
-              else
-                Map.delete(waiting, waiting_key)
-              end
-            end)
-
-          {state, pending}
-        end
-      )
-
-    # Send responses for any pending get_result requests so the worker
-    # doesn't hang waiting for a reply that will never come
+    # Send responses for any pending select requests so the worker doesn't
+    # hang waiting for a reply that will never come. Since the execution is
+    # being cleaned up (abort/suspend), we send :timeout to let the client
+    # know the wait is over — the process will be killed separately.
     case find_session_for_execution(state, execution_ext_id) do
       {:ok, session_id} ->
-        Enum.reduce(pending_request_ids, state, fn request_id, state ->
-          send_session(state, session_id, {:result, request_id, :suspended})
+        Enum.reduce(removed_by_request, state, fn {_, entry}, state ->
+          send_session(
+            state,
+            session_id,
+            {:result, entry.request_id, :timeout}
+          )
         end)
 
       :error ->

--- a/server/lib/coflux/store.ex
+++ b/server/lib/coflux/store.ex
@@ -42,6 +42,12 @@ defmodule Coflux.Store do
   end
 
   def with_snapshot(db, fun) do
+    # SQLite's ROLLBACK TO reverts changes but leaves the savepoint on the
+    # stack — a subsequent RELEASE is required to actually pop it (and
+    # commit the implicit transaction when it's the outermost savepoint).
+    # Missing the RELEASE leaks the implicit transaction, which breaks
+    # any following BEGIN with "cannot start a transaction within a
+    # transaction".
     name = "s#{:erlang.unique_integer([:positive])}"
     :ok = Sqlite3.execute(db, "SAVEPOINT #{name}")
 
@@ -50,6 +56,7 @@ defmodule Coflux.Store do
     rescue
       e ->
         :ok = Sqlite3.execute(db, "ROLLBACK TO #{name}")
+        :ok = Sqlite3.execute(db, "RELEASE #{name}")
         reraise e, __STACKTRACE__
     else
       {:ok, result} ->
@@ -58,6 +65,7 @@ defmodule Coflux.Store do
 
       {:error, reason} ->
         :ok = Sqlite3.execute(db, "ROLLBACK TO #{name}")
+        :ok = Sqlite3.execute(db, "RELEASE #{name}")
         {:error, reason}
     end
   end

--- a/server/priv/migrations/orchestration/3.sql
+++ b/server/priv/migrations/orchestration/3.sql
@@ -58,10 +58,10 @@ CREATE TABLE execution_inputs (
   FOREIGN KEY (input_id) REFERENCES inputs ON DELETE RESTRICT
 ) STRICT;
 
--- Input responses: type 1 = value, type 2 = dismissed
+-- Input responses: type 1 = value, type 2 = dismissed, type 3 = cancelled
 CREATE TABLE input_responses (
   input_id INTEGER PRIMARY KEY,
-  type INTEGER NOT NULL CHECK (type IN (1, 2)),
+  type INTEGER NOT NULL CHECK (type IN (1, 2, 3)),
   value TEXT,
   created_at INTEGER NOT NULL,
   created_by INTEGER REFERENCES principals ON DELETE SET NULL,

--- a/tests/support/executor.py
+++ b/tests/support/executor.py
@@ -177,8 +177,12 @@ class ExecutorConnection:
         )
 
     def cancel(self, execution_id, target_execution_id):
-        """Cancel a child execution."""
-        msg = protocol.cancel_execution_request(None, execution_id, target_execution_id)
+        """Cancel a child execution (convenience wrapper over cancel_request)."""
+        msg = protocol.cancel_request(
+            None,
+            execution_id,
+            [protocol.execution_handle(target_execution_id)],
+        )
         return self._request(msg)
 
     def suspend(self, execution_id, execute_after=None):

--- a/tests/support/executor.py
+++ b/tests/support/executor.py
@@ -5,6 +5,40 @@ from collections import namedtuple
 
 from . import protocol
 
+
+def _unwrap_select_result(result):
+    """Translate a select result to the legacy resolve_reference / resolve_input shape.
+
+    The select protocol always returns a dict with a status field. The old
+    wait RPCs returned:
+      - value:     {"type": "inline", ..., "value": ...} (the value directly)
+      - error:     {"status": "error", "error_type": "...", "error_message": "..."}
+      - cancelled: {"status": "cancelled"}
+      - dismissed: {"status": "dismissed"}
+      - timeout:   None
+
+    Convert so existing tests that compare against those shapes keep working.
+    """
+    if result is None:
+        return None
+    if not isinstance(result, dict):
+        return result
+    status = result.get("status")
+    if status == "ok":
+        return result.get("value")
+    if status == "timeout":
+        return None
+    if status == "error":
+        err = result.get("error") or {}
+        return {
+            "status": "error",
+            "error_type": err.get("type", ""),
+            "error_message": err.get("message", ""),
+        }
+    if status in ("cancelled", "dismissed"):
+        return {"status": status}
+    return result
+
 Execution = namedtuple("Execution", ["conn", "execution_id", "module", "target", "arguments"])
 
 
@@ -92,25 +126,55 @@ class ExecutorConnection:
         resp = self._request(msg)
         return resp["result"]["execution_id"]
 
-    def resolve(self, execution_id, target_execution_id):
-        """Resolve a reference and return the result dict (or error dict)."""
-        msg = protocol.resolve_reference_request(
-            None, execution_id, target_execution_id
+    def select(
+        self,
+        execution_id,
+        handles,
+        timeout_ms=None,
+        suspend=True,
+        cancel_remaining=False,
+    ):
+        """Send a select request and return the result dict (or error dict).
+
+        ``handles`` is a list of handle specs built via
+        ``protocol.execution_handle(id)`` or ``protocol.input_handle(id)``.
+        """
+        msg = protocol.select_request(
+            None,
+            execution_id,
+            handles,
+            timeout_ms=timeout_ms,
+            suspend=suspend,
+            cancel_remaining=cancel_remaining,
         )
         resp = self._request(msg)
         return resp.get("result", resp.get("error"))
+
+    def resolve(self, execution_id, target_execution_id):
+        """Resolve a single execution reference (convenience over select).
+
+        Returns the legacy resolve_reference shape for backward compatibility.
+        """
+        return _unwrap_select_result(
+            self.select(
+                execution_id,
+                [protocol.execution_handle(target_execution_id)],
+            )
+        )
 
     def poll(self, execution_id, target_execution_id, timeout_ms=0):
-        """Poll for a reference result without suspending.
+        """Poll for an execution result without suspending.
 
-        Returns the result dict, or None if not yet available.
+        Returns the legacy shape (or None if the poll timed out).
         """
-        msg = protocol.resolve_reference_request(
-            None, execution_id, target_execution_id,
-            timeout_ms=timeout_ms, suspend=False,
+        return _unwrap_select_result(
+            self.select(
+                execution_id,
+                [protocol.execution_handle(target_execution_id)],
+                timeout_ms=timeout_ms,
+                suspend=False,
+            )
         )
-        resp = self._request(msg)
-        return resp.get("result", resp.get("error"))
 
     def cancel(self, execution_id, target_execution_id):
         """Cancel a child execution."""
@@ -148,23 +212,28 @@ class ExecutorConnection:
             return result["input_id"]
         return result
 
-    def resolve_input(self, input_external_id, from_execution_id, **kwargs):
-        """Resolve an input and return the result dict.
+    def resolve_input(
+        self, input_external_id, from_execution_id, timeout_ms=None, suspend=True
+    ):
+        """Resolve an input (convenience over select).
 
-        Returns the raw result dict from the server. For a value response
-        this looks like {"type": "inline", "format": "json", "value": ...}.
-        For dismissed: {"status": "dismissed"}.
-        For suspended: {"status": "suspended"}.
-        Returns None if the poll timed out with no response.
-        Raises RuntimeError if the server returned an error.
+        Returns the legacy resolve_input shape:
+          - value: the raw value dict
+          - dismissed: {"status": "dismissed"}
+          - timeout: None
+        Raises RuntimeError if the server returned a protocol-level error.
         """
-        msg = protocol.resolve_input_request(
-            None, input_external_id, from_execution_id, **kwargs
+        msg = protocol.select_request(
+            None,
+            from_execution_id,
+            [protocol.input_handle(input_external_id)],
+            timeout_ms=timeout_ms,
+            suspend=suspend,
         )
         resp = self._request(msg)
         if "error" in resp:
-            raise RuntimeError(f"resolve_input error: {resp['error']}")
-        return resp.get("result")
+            raise RuntimeError(f"select error: {resp['error']}")
+        return _unwrap_select_result(resp.get("result"))
 
     def complete(self, execution_id, value=None):
         """Send execution_result."""

--- a/tests/support/protocol.py
+++ b/tests/support/protocol.py
@@ -103,20 +103,40 @@ def submit_execution_request(
     return {"id": request_id, "method": "submit_execution", "params": params}
 
 
-def resolve_reference_request(request_id, execution_id, target_execution_id, timeout_ms=None, suspend=None):
+def select_request(
+    request_id,
+    execution_id,
+    handles,
+    timeout_ms=None,
+    suspend=True,
+    cancel_remaining=False,
+):
+    """Build a select request.
+
+    handles is a list of dicts like ``{"type": "execution"|"input", "id": "..."}``.
+    """
     params = {
         "execution_id": execution_id,
-        "target_execution_id": target_execution_id,
+        "handles": handles,
+        "suspend": suspend,
     }
     if timeout_ms is not None:
         params["timeout_ms"] = timeout_ms
-    if suspend is not None:
-        params["suspend"] = suspend
+    if cancel_remaining:
+        params["cancel_remaining"] = cancel_remaining
     return {
         "id": request_id,
-        "method": "resolve_reference",
+        "method": "select",
         "params": params,
     }
+
+
+def execution_handle(execution_id):
+    return {"type": "execution", "id": execution_id}
+
+
+def input_handle(input_id):
+    return {"type": "input", "id": input_id}
 
 
 _LEVEL_MAP = {
@@ -236,19 +256,3 @@ def submit_input_request(
     return {"id": request_id, "method": "submit_input", "params": params}
 
 
-def resolve_input_request(
-    request_id,
-    input_external_id,
-    from_execution_id,
-    timeout_ms=None,
-    suspend=None,
-):
-    params = {
-        "input_external_id": input_external_id,
-        "from_execution_id": from_execution_id,
-    }
-    if timeout_ms is not None:
-        params["timeout_ms"] = timeout_ms
-    if suspend is not None:
-        params["suspend"] = suspend
-    return {"id": request_id, "method": "resolve_input", "params": params}

--- a/tests/support/protocol.py
+++ b/tests/support/protocol.py
@@ -180,13 +180,18 @@ def json_args(*values):
     return [{"type": "inline", "format": "json", "value": v} for v in values]
 
 
-def cancel_execution_request(request_id, execution_id, target_execution_id):
+def cancel_request(request_id, execution_id, handles):
+    """Build a cancel request.
+
+    ``handles`` is a list of handle specs built via
+    ``protocol.execution_handle(id)`` or ``protocol.input_handle(id)``.
+    """
     return {
         "id": request_id,
-        "method": "cancel_execution",
+        "method": "cancel",
         "params": {
             "execution_id": execution_id,
-            "target_execution_id": target_execution_id,
+            "handles": handles,
         },
     }
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -232,6 +232,39 @@ def test_input_poll_no_response_yet(worker):
         assert ctx.result(resp["runId"])["type"] == "value"
 
 
+def test_input_cancel_via_cancel_rpc(worker):
+    """Cancelling an input via the cancel RPC transitions it to cancelled.
+
+    After cancellation, resolving returns status=cancelled (distinct from
+    the dismissed path), and any select waiting on the input is notified.
+    """
+    targets = [workflow("test", "cancel_input")]
+
+    with worker(targets) as ctx:
+        resp = ctx.submit("test", "cancel_input")
+        ex = ctx.executor.next_execute()
+
+        input_id = ex.conn.submit_input(ex.execution_id, "Please cancel me")
+
+        # Cancel the input via the unified cancel RPC
+        cancel_msg = protocol.cancel_request(
+            None,
+            ex.execution_id,
+            [protocol.input_handle(input_id)],
+        )
+        cancel_msg["id"] = 9001
+        ex.conn.send(cancel_msg)
+        cancel_resp = ex.conn.recv()
+        assert cancel_resp["id"] == 9001
+
+        # Resolving the input should now surface the cancellation
+        resolve_result = ex.conn.resolve_input(input_id, ex.execution_id)
+        assert resolve_result == {"status": "cancelled"}
+
+        ex.conn.complete(ex.execution_id, value="cancelled-ok")
+        assert ctx.result(resp["runId"])["type"] == "value"
+
+
 def test_input_wait_then_respond(worker):
     """resolve_input blocks until the input is responded to."""
     targets = [workflow("test", "blocking")]

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -173,8 +173,12 @@ def test_input_suspends_execution(worker):
 
         # Resolve with suspend — the worker will suspend and kill this executor.
         # We send the request but the connection closes before we get a response.
-        msg = protocol.resolve_input_request(
-            None, input_id, ex.execution_id, timeout_ms=0, suspend=True
+        msg = protocol.select_request(
+            None,
+            ex.execution_id,
+            [protocol.input_handle(input_id)],
+            timeout_ms=0,
+            suspend=True,
         )
         msg["id"] = 999
         ex.conn.send(msg)


### PR DESCRIPTION
This reworks how executions (and inputs) are resolved - instead of resolving a single execution, a 'select' supports specifying multiple executions (and inputs), which then get raced, with the server returning the first to complete. This allows implementing tasks that process executions as they become available, rather than having to wait for them in order. A select can also choose to have the server cancel the 'losing' executions.

And this similarly reworks 'cancel' so there's a single method for cancelling executions and inputs. And support cancelling multiple items atomically.

And this updates tasks/workflow definitions to support async functions.

And adds a fluent interface for configuring targets - e.g., `my_task.with_retries(3).with_requires({"gpu": True}).submit()`.